### PR TITLE
Okta-362451 IDX updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ var codeVerifier = idxContext.CodeVerifier;
 ### Get State Handle
 
 ```csharp
-// optional with interactionHandle or empty; if empty, a new interactionHandle will be obtained
-var introspectResponse = await client.IntrospectAsync(interactResponse.InteractionHandle);
+var introspectResponse = await client.IntrospectAsync(idxContext);
 var stateHandle = introspectResponse.StateHandle;
 ```
 
@@ -96,8 +95,11 @@ var client = new IdxClient(new IdxConfiguration()
                 Scopes = "openid profile offline_access", // Optional. The default value is "openid profile".
             });
 
-// Call Introspect - interactionHandle is optional; if it's not provided, a new interactionHandle will be obtained.
-var introspectResponse = await client.IntrospectAsync();
+// Call Interact to obtain an IDX context
+var idxContext = await client.InteractAsync();
+
+// Continue with Introspect
+var introspectResponse = await client.IntrospectAsync(idxContext);
 
 // Identify with username 
 var identifyRequest = new IdxRequestPayload();
@@ -122,7 +124,7 @@ var challengeResponse = await identifyResponse.Remediation.RemediationOptions
                                             .ProceedAsync(identifyRequest);   
 
 // Exchange tokens
-var tokenResponse = await challengeResponse.SuccessWithInteractionCode.ExchangeCodeAsync();
+var tokenResponse = await challengeResponse.SuccessWithInteractionCode.ExchangeCodeAsync(idxContext);
 
 ```
 
@@ -135,8 +137,11 @@ In this example, the Org is configured to require an email as a second authentic
 ```csharp
 var client = new IdxClient();
 
-// Call Introspect - interactionHandle is optional; if it's not provided, a new interactionHandle will be obtained.
-var introspectResponse = await client.IntrospectAsync();
+// Call Interact to obtain an IDX context
+var idxContext = await client.InteractAsync();
+
+// Continue with Introspect
+var introspectResponse = await client.IntrospectAsync(idxContext);
 
 // Identify with username 
 var identifyRequest = new IdxRequestPayload();
@@ -163,10 +168,10 @@ var challengeResponse = await identifyResponse.Remediation.RemediationOptions
 // Before answering the email challenge, cancel the transaction
 await challengeResponse.CancelAsync();
 
-// Get a new interaction code
-interactResponse = await client.InteractAsync();
+// Get a new IDX context
+idxContext = await client.InteractAsync();
 
-// From now on, you can use interactResponse.InteractionHandle to continue with a new flow.
+// From now on, you can use the new IDX context to continue with a new flow.
 ```                                            
 
 ### Remediation/MFA scenarios with sign-on policy
@@ -180,7 +185,11 @@ In this example, the Org is configured to require a security question as a secon
 ```csharp
 var client = new IdxClient();
 
-var introspectResponse = await client.IntrospectAsync();
+// Call Interact to obtain an IDX context
+var idxContext = await client.InteractAsync();
+
+// Continue with Introspect
+var introspectResponse = await client.IntrospectAsync(idxContext);
 
 var identifyRequest = new IdxRequestPayload();
 identifyRequest.StateHandle = introspectResponse.StateHandle;
@@ -263,7 +272,7 @@ var skipResponse = await enrollResponse.Remediation.RemediationOptions
                             .ProceedAsync(skipRequest);
 
 
-var tokenResponse = await skipResponse.SuccessWithInteractionCode.ExchangeCodeAsync();
+var tokenResponse = await skipResponse.SuccessWithInteractionCode.ExchangeCodeAsync(idxContext);
 ```
 
 #### Login using password + email authenticator
@@ -277,7 +286,11 @@ In this example, the Org is configured to require an email as a second authentic
 ```csharp
 var client = new IdxClient();
 
-var introspectResponse = await client.IntrospectAsync();
+// Call Interact to obtain an IDX context
+var idxContext = await client.InteractAsync();
+
+// Continue with Introspect
+var introspectResponse = await client.IntrospectAsync(idxContext);
 
 var identifyRequest = new IdxRequestPayload();
 identifyRequest.StateHandle = introspectResponse.StateHandle;
@@ -369,7 +382,7 @@ var challengeEmailResponse = await selectEmailAuthenticatorResponse.Remediation.
 
 if (challengeEmailResponse.IsLoginSuccess)
 {
-    var tokenResponse = await challengeEmailResponse.SuccessWithInteractionCode.ExchangeCodeAsync();
+    var tokenResponse = await challengeEmailResponse.SuccessWithInteractionCode.ExchangeCodeAsync(idxContext);
 }
 ```
 
@@ -382,7 +395,11 @@ In this example, the Org is configured with fingerprint as a second authenticato
 ```csharp
 var client = new IdxClient();
 
-var introspectResponse = await client.IntrospectAsync();
+// Call Interact to obtain an IDX context
+var idxContext = await client.InteractAsync();
+
+// Continue with Introspect
+var introspectResponse = await client.IntrospectAsync(idxContext);
 
 var identifyRequest = new IdxRequestPayload();
 identifyRequest.StateHandle = introspectResponse.StateHandle;
@@ -465,7 +482,7 @@ var challengeFingerprintResponse = await selectFingerprintResponse.Remediation.R
                                 .ProceedAsync(challengeFingerprintRequest);
 
 // Exchange tokens
-var tokenResponse = await challengeFingerprintResponse.SuccessWithInteractionCode.ExchangeCodeAsync();
+var tokenResponse = await challengeFingerprintResponse.SuccessWithInteractionCode.ExchangeCodeAsync(idxContext);
 ```
 
 #### Login using password + enroll phone authenticator (SMS/Voice)
@@ -478,7 +495,11 @@ In this example, the Org is configured with phone as a second authenticator. Aft
 ```csharp
 var client = new IdxClient();
 
-var introspectResponse = await client.IntrospectAsync();
+// Call Interact to obtain an IDX context
+var idxContext = await client.InteractAsync();
+
+// Continue with Introspect
+var introspectResponse = await client.IntrospectAsync(idxContext);
 
 // Identify with username
 var identifyRequest = new IdxRequestPayload();
@@ -570,7 +591,7 @@ var challengePhoneResponse = await selectPhoneAuthenticatorResponse.Remediation.
                                                     .ProceedAsync(challengePhoneRequest);
 
 // Exchange tokens
-var tokenResponse = await challengePhoneResponse.SuccessWithInteractionCode.ExchangeCodeAsync();
+var tokenResponse = await challengePhoneResponse.SuccessWithInteractionCode.ExchangeCodeAsync(idxContext);
 
 ```
 
@@ -584,7 +605,11 @@ In this example, the Org is configured with web authenticator as a second authen
 ```csharp
 var client = new IdxClient();
 
-var introspectResponse = await client.IntrospectAsync();
+// Call Interact to obtain an IDX context
+var idxContext = await client.InteractAsync();
+
+// Continue with Introspect
+var introspectResponse = await client.IntrospectAsync(idxContext);
 
 var identifyRequest = new IdxRequestPayload();
 identifyRequest.StateHandle = introspectResponse.StateHandle;
@@ -672,7 +697,7 @@ var challengeFingerprintResponse = await selectFingerprintResponse.Remediation.R
                                 .ProceedAsync(challengeFingerprintRequest);
 
 // Exchange tokens
-var tokenResponse = await challengeFingerprintResponse.SuccessWithInteractionCode.ExchangeCodeAsync();
+var tokenResponse = await challengeFingerprintResponse.SuccessWithInteractionCode.ExchangeCodeAsync(idxContext);
 ```
 
 #### Login using password + email authenticator + enroll phone + enroll security question
@@ -684,7 +709,12 @@ In this example, the Org is configured to require email, phone and security ques
 ```csharp
 var client = new IdxClient();
 
-var introspectResponse = await client.IntrospectAsync();
+// Call Interact to obtain an IDX context
+var idxContext = await client.InteractAsync();
+
+// Continue with Introspect
+var introspectResponse = await client.IntrospectAsync(idxContext);
+
 var identifyRequest = new IdxRequestPayload();
 identifyRequest.StateHandle = introspectResponse.StateHandle;
 identifyRequest.SetProperty("identifier", "test-mfa@okta.com");
@@ -880,7 +910,7 @@ var skipResponse = await enrollResponse.Remediation.RemediationOptions
                             .ProceedAsync(skipRequest);
 
 
-var tokenResponse = await skipResponse.SuccessWithInteractionCode.ExchangeCodeAsync();
+var tokenResponse = await skipResponse.SuccessWithInteractionCode.ExchangeCodeAsync(idxContext);
 
 ```
 
@@ -889,7 +919,11 @@ var tokenResponse = await skipResponse.SuccessWithInteractionCode.ExchangeCodeAs
 ```csharp
 var client = new IdxClient();
 
-var introspectResponse = await client.IntrospectAsync();
+// Call Interact to obtain an IDX context
+var idxContext = await client.InteractAsync();
+
+// Continue with Introspect
+var introspectResponse = await client.IntrospectAsync(idxContext);
 
 // Identify with username
 var identifyRequest = new IdxRequestPayload();
@@ -992,7 +1026,7 @@ var challengePhoneResponse = await selectPhoneAuthenticatorResponse.Remediation.
                                                     .ProceedAsync(challengePhoneRequest);
 
 // Exchange tokens
-var tokenResponse = await challengePhoneResponse.SuccessWithInteractionCode.ExchangeCodeAsync();
+var tokenResponse = await challengePhoneResponse.SuccessWithInteractionCode.ExchangeCodeAsync(idxContext);
 
 ```
 
@@ -1004,7 +1038,11 @@ In this example, the Org is configured to require additional attributes when use
 
 ```csharp
 var client = new IdxClient();
-var introspectResponse = await client.IntrospectAsync();
+// Call Interact to obtain an IDX context
+var idxContext = await client.InteractAsync();
+
+// Continue with Introspect
+var introspectResponse = await client.IntrospectAsync(idxContext);
 
 // Identify with username
 var identifyRequest = new IdxRequestPayload();
@@ -1080,8 +1118,7 @@ var idxResponse = await client.CancelAsync();
 
 ```csharp
 if (idxResponse.IsLoginSuccessful) {
-    // exchange interaction code for token
-    var tokenResponse = await challengeResponse.SuccessWithInteractionCode.ExchangeCodeAsync();
+    var tokenResponse = await challengeResponse.SuccessWithInteractionCode.ExchangeCodeAsync(idxContext);
     var accessToken = tokenResponse.AccessToken;
     var idToken = tokenResponse.IdToken;
 }

--- a/README.md
+++ b/README.md
@@ -63,11 +63,12 @@ var client = new IdxClient(new IdxConfiguration()
             });
 ```
 
-### Get Interaction Handle
+### Get Interaction Handle and Code Verifier
 
 ```csharp
-var interactResponse = await client.InteractAsync();
-var interactHandle = interactResponse.InteractionHandle;
+var idxContext = await client.InteractAsync();
+var interactHandle = idxContext.InteractionHandle;
+var codeVerifier = idxContext.CodeVerifier;
 ```
 
 ### Get State Handle

--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,8 @@
-// Default MSBuild configuration arguments
+#addin nuget:?package=Cake.Figlet&version=1.3.1
 
+var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Release");
+
 
 Task("Clean")
 .Does(() =>
@@ -78,9 +80,21 @@ Task("IntegrationTest")
     }
 });
 
+Task("Info")
+.Does(() => 
+{
+    Information(Figlet("Okta.Idx.Sdk"));
+
+    var cakeVersion = typeof(ICakeContext).Assembly.GetName().Version.ToString();
+
+    Information("Building using {0} version of Cake", cakeVersion);
+});
+
+
 // Define top-level tasks
 
 Task("Default")
+    .IsDependentOn("Info")
     .IsDependentOn("Clean")
     .IsDependentOn("Restore")
     .IsDependentOn("Build")
@@ -94,6 +108,4 @@ Task("DefaultIT")
     .IsDependentOn("IntegrationTest")
     .IsDependentOn("Pack");
 
-// Default task
-var target = Argument("target", "Default");
 RunTarget(target);

--- a/src/Okta.Idx.Sdk.IntegrationTests/IdxClientShould.cs
+++ b/src/Okta.Idx.Sdk.IntegrationTests/IdxClientShould.cs
@@ -16,7 +16,7 @@ namespace Okta.Idx.Sdk.IntegrationTests
 
             var idxContext = await ((IdxClient)client).InteractAsync();
 
-            var response = await client.IntrospectAsync(idxContext.InteractionHandle);
+            var response = await client.IntrospectAsync(idxContext);
 
             response.StateHandle.Should().NotBeNullOrEmpty();
             response.Version.Should().NotBeNullOrEmpty();
@@ -46,7 +46,7 @@ namespace Okta.Idx.Sdk.IntegrationTests
 
             var idxContext = await client.InteractAsync();
 
-            var introspectResponse = await client.IntrospectAsync(idxContext.InteractionHandle);
+            var introspectResponse = await client.IntrospectAsync(idxContext);
 
             var identifyRequest = new IdxRequestPayload();
             identifyRequest.StateHandle = introspectResponse.StateHandle;
@@ -85,7 +85,7 @@ namespace Okta.Idx.Sdk.IntegrationTests
 
             var idxContext = await client.InteractAsync();
 
-            var introspectResponse = await client.IntrospectAsync(idxContext.InteractionHandle);
+            var introspectResponse = await client.IntrospectAsync(idxContext);
 
             var identifyRequest = new IdxRequestPayload();
             identifyRequest.StateHandle = introspectResponse.StateHandle;
@@ -130,7 +130,7 @@ namespace Okta.Idx.Sdk.IntegrationTests
 
             var idxContext = await client.InteractAsync();
 
-            var introspectResponse = await client.IntrospectAsync(idxContext.InteractionHandle);
+            var introspectResponse = await client.IntrospectAsync(idxContext);
 
             var identifyRequest = new IdxRequestPayload();
             identifyRequest.StateHandle = introspectResponse.StateHandle;
@@ -214,7 +214,7 @@ namespace Okta.Idx.Sdk.IntegrationTests
 
             var idxContext = await client.InteractAsync();
 
-            var introspectResponse = await client.IntrospectAsync(idxContext.InteractionHandle);
+            var introspectResponse = await client.IntrospectAsync(idxContext);
 
             // TODO: Create user and assign user to application.
 
@@ -316,7 +316,7 @@ namespace Okta.Idx.Sdk.IntegrationTests
 
             var idxContext = await client.InteractAsync();
 
-            var introspectResponse = await client.IntrospectAsync(idxContext.InteractionHandle);
+            var introspectResponse = await client.IntrospectAsync(idxContext);
 
             // TODO: Create user and assign user to application.
 
@@ -416,7 +416,7 @@ namespace Okta.Idx.Sdk.IntegrationTests
 
             var idxContext = await client.InteractAsync();
 
-            var introspectResponse = await client.IntrospectAsync(idxContext.InteractionHandle);
+            var introspectResponse = await client.IntrospectAsync(idxContext);
 
             // TODO: Create user and assign user to application.
 
@@ -628,7 +628,7 @@ namespace Okta.Idx.Sdk.IntegrationTests
 
             var idxContext = await client.InteractAsync();
 
-            var introspectResponse = await client.IntrospectAsync(idxContext.InteractionHandle);
+            var introspectResponse = await client.IntrospectAsync(idxContext);
 
             // TODO: Create user and assign user to application.
 
@@ -737,7 +737,7 @@ namespace Okta.Idx.Sdk.IntegrationTests
 
             var idxContext = await client.InteractAsync();
 
-            var introspectResponse = await client.IntrospectAsync(idxContext.InteractionHandle);
+            var introspectResponse = await client.IntrospectAsync(idxContext);
 
             var identifyRequest = new IdxRequestPayload();
             identifyRequest.StateHandle = introspectResponse.StateHandle;
@@ -836,7 +836,7 @@ namespace Okta.Idx.Sdk.IntegrationTests
 
             var idxContext = await client.InteractAsync();
 
-            var introspectResponse = await client.IntrospectAsync(idxContext.InteractionHandle);
+            var introspectResponse = await client.IntrospectAsync(idxContext);
 
             var identifyRequest = new IdxRequestPayload();
             identifyRequest.StateHandle = introspectResponse.StateHandle;
@@ -934,7 +934,7 @@ namespace Okta.Idx.Sdk.IntegrationTests
 
             var idxContext = await client.InteractAsync();
 
-            var introspectResponse = await client.IntrospectAsync(idxContext.InteractionHandle);
+            var introspectResponse = await client.IntrospectAsync(idxContext);
 
             var identifyRequest = new IdxRequestPayload();
             identifyRequest.StateHandle = introspectResponse.StateHandle;

--- a/src/Okta.Idx.Sdk.IntegrationTests/IdxClientShould.cs
+++ b/src/Okta.Idx.Sdk.IntegrationTests/IdxClientShould.cs
@@ -14,9 +14,9 @@ namespace Okta.Idx.Sdk.IntegrationTests
         {
             var client = TestIdxClient.Create();
 
-            var interactResponse = await ((IdxClient)client).InteractAsync();
+            var idxContext = await ((IdxClient)client).InteractAsync();
 
-            var response = await client.IntrospectAsync(interactResponse.InteractionHandle);
+            var response = await client.IntrospectAsync(idxContext.InteractionHandle);
 
             response.StateHandle.Should().NotBeNullOrEmpty();
             response.Version.Should().NotBeNullOrEmpty();
@@ -44,9 +44,9 @@ namespace Okta.Idx.Sdk.IntegrationTests
         {
             var client = TestIdxClient.Create();
 
-            var interactResponse = await client.InteractAsync();
+            var idxContext = await client.InteractAsync();
 
-            var introspectResponse = await client.IntrospectAsync(interactResponse.InteractionHandle);
+            var introspectResponse = await client.IntrospectAsync(idxContext.InteractionHandle);
 
             var identifyRequest = new IdxRequestPayload();
             identifyRequest.StateHandle = introspectResponse.StateHandle;
@@ -74,7 +74,7 @@ namespace Okta.Idx.Sdk.IntegrationTests
 
             var cancelResponse =  await identifyResponse.CancelAsync();
 
-            await Assert.ThrowsAsync<OktaApiException>(() => challengeResponse.SuccessWithInteractionCode.ExchangeCodeAsync());
+            await Assert.ThrowsAsync<OktaApiException>(() => challengeResponse.SuccessWithInteractionCode.ExchangeCodeAsync(idxContext));
         }
 
 
@@ -83,9 +83,9 @@ namespace Okta.Idx.Sdk.IntegrationTests
         {
             var client = TestIdxClient.Create();
 
-            var interactResponse = await client.InteractAsync();
+            var idxContext = await client.InteractAsync();
 
-            var introspectResponse = await client.IntrospectAsync(interactResponse.InteractionHandle);
+            var introspectResponse = await client.IntrospectAsync(idxContext.InteractionHandle);
 
             var identifyRequest = new IdxRequestPayload();
             identifyRequest.StateHandle = introspectResponse.StateHandle;
@@ -115,7 +115,7 @@ namespace Okta.Idx.Sdk.IntegrationTests
 
 
 
-            var token = await challengeResponse.SuccessWithInteractionCode.ExchangeCodeAsync();
+            var token = await challengeResponse.SuccessWithInteractionCode.ExchangeCodeAsync(idxContext);
 
             token.AccessToken.Should().NotBeNullOrEmpty();
         }
@@ -128,9 +128,9 @@ namespace Okta.Idx.Sdk.IntegrationTests
             // Create an app with email required and set secrets via env var
             var client = TestIdxClient.Create();
 
-            var interactResponse = await client.InteractAsync();
+            var idxContext = await client.InteractAsync();
 
-            var introspectResponse = await client.IntrospectAsync(interactResponse.InteractionHandle);
+            var introspectResponse = await client.IntrospectAsync(idxContext.InteractionHandle);
 
             var identifyRequest = new IdxRequestPayload();
             identifyRequest.StateHandle = introspectResponse.StateHandle;
@@ -196,9 +196,12 @@ namespace Okta.Idx.Sdk.IntegrationTests
             await selectEmailResponse.CancelAsync();
 
             // Get a new interaction code
-            interactResponse = await client.InteractAsync();
+            idxContext = await client.InteractAsync();
 
-            interactResponse.InteractionHandle.Should().NotBeNullOrEmpty();
+            idxContext.InteractionHandle.Should().NotBeNullOrEmpty();
+            idxContext.CodeChallenge.Should().NotBeNullOrEmpty();
+            idxContext.CodeVerifier.Should().NotBeNullOrEmpty();
+            idxContext.CodeChallengeMethod.Should().NotBeNullOrEmpty();
         }
 
         // This test requires a policy with security question as a required second factor.
@@ -209,9 +212,9 @@ namespace Okta.Idx.Sdk.IntegrationTests
             // Create an app with email required and set secrets via env var
             var client = TestIdxClient.Create();
 
-            var interactResponse = await client.InteractAsync();
+            var idxContext = await client.InteractAsync();
 
-            var introspectResponse = await client.IntrospectAsync(interactResponse.InteractionHandle);
+            var introspectResponse = await client.IntrospectAsync(idxContext.InteractionHandle);
 
             // TODO: Create user and assign user to application.
 
@@ -298,7 +301,7 @@ namespace Okta.Idx.Sdk.IntegrationTests
                                         .ProceedAsync(skipRequest);
 
 
-            var tokenResponse = await skipResponse.SuccessWithInteractionCode.ExchangeCodeAsync();
+            var tokenResponse = await skipResponse.SuccessWithInteractionCode.ExchangeCodeAsync(idxContext);
 
             tokenResponse.AccessToken.Should().NotBeNullOrEmpty();
         }
@@ -311,9 +314,9 @@ namespace Okta.Idx.Sdk.IntegrationTests
             // Create an app with email required and set secrets via env var
             var client = TestIdxClient.Create();
 
-            var interactResponse = await client.InteractAsync();
+            var idxContext = await client.InteractAsync();
 
-            var introspectResponse = await client.IntrospectAsync(interactResponse.InteractionHandle);
+            var introspectResponse = await client.IntrospectAsync(idxContext.InteractionHandle);
 
             // TODO: Create user and assign user to application.
 
@@ -399,7 +402,7 @@ namespace Okta.Idx.Sdk.IntegrationTests
                                                                 .ProceedAsync(challengeEmailRequest);
 
 
-            var tokenResponse = await challengeEmailResponse.SuccessWithInteractionCode.ExchangeCodeAsync();
+            var tokenResponse = await challengeEmailResponse.SuccessWithInteractionCode.ExchangeCodeAsync(idxContext);
 
             tokenResponse.AccessToken.Should().NotBeNullOrEmpty();
         }
@@ -411,9 +414,9 @@ namespace Okta.Idx.Sdk.IntegrationTests
             // Create an app with email required and set secrets via env var
             var client = TestIdxClient.Create();
 
-            var interactResponse = await client.InteractAsync();
+            var idxContext = await client.InteractAsync();
 
-            var introspectResponse = await client.IntrospectAsync(interactResponse.InteractionHandle);
+            var introspectResponse = await client.IntrospectAsync(idxContext.InteractionHandle);
 
             // TODO: Create user and assign user to application.
 
@@ -611,7 +614,7 @@ namespace Okta.Idx.Sdk.IntegrationTests
                                         .ProceedAsync(skipRequest);
 
 
-            var tokenResponse = await skipResponse.SuccessWithInteractionCode.ExchangeCodeAsync();
+            var tokenResponse = await skipResponse.SuccessWithInteractionCode.ExchangeCodeAsync(idxContext);
 
         }
 
@@ -623,9 +626,9 @@ namespace Okta.Idx.Sdk.IntegrationTests
             // Create an app with email required and set secrets via env var
             var client = TestIdxClient.Create();
 
-            var interactResponse = await client.InteractAsync();
+            var idxContext = await client.InteractAsync();
 
-            var introspectResponse = await client.IntrospectAsync(interactResponse.InteractionHandle);
+            var introspectResponse = await client.IntrospectAsync(idxContext.InteractionHandle);
 
             // TODO: Create user and assign user to application.
 
@@ -721,7 +724,7 @@ namespace Okta.Idx.Sdk.IntegrationTests
                                                                 .ProceedAsync(challengePhoneRequest);
 
 
-            var tokenResponse = await challengePhoneResponse.SuccessWithInteractionCode.ExchangeCodeAsync();
+            var tokenResponse = await challengePhoneResponse.SuccessWithInteractionCode.ExchangeCodeAsync(idxContext);
 
             tokenResponse.AccessToken.Should().NotBeNullOrEmpty();
         }
@@ -732,9 +735,9 @@ namespace Okta.Idx.Sdk.IntegrationTests
         {
             var client = TestIdxClient.Create();
 
-            var interactResponse = await client.InteractAsync();
+            var idxContext = await client.InteractAsync();
 
-            var introspectResponse = await client.IntrospectAsync(interactResponse.InteractionHandle);
+            var introspectResponse = await client.IntrospectAsync(idxContext.InteractionHandle);
 
             var identifyRequest = new IdxRequestPayload();
             identifyRequest.StateHandle = introspectResponse.StateHandle;
@@ -831,9 +834,9 @@ namespace Okta.Idx.Sdk.IntegrationTests
         {
             var client = TestIdxClient.Create();
 
-            var interactResponse = await client.InteractAsync();
+            var idxContext = await client.InteractAsync();
 
-            var introspectResponse = await client.IntrospectAsync(interactResponse.InteractionHandle);
+            var introspectResponse = await client.IntrospectAsync(idxContext.InteractionHandle);
 
             var identifyRequest = new IdxRequestPayload();
             identifyRequest.StateHandle = introspectResponse.StateHandle;
@@ -929,9 +932,9 @@ namespace Okta.Idx.Sdk.IntegrationTests
         {
             var client = TestIdxClient.Create();
 
-            var interactResponse = await client.InteractAsync();
+            var idxContext = await client.InteractAsync();
 
-            var introspectResponse = await client.IntrospectAsync(interactResponse.InteractionHandle);
+            var introspectResponse = await client.IntrospectAsync(idxContext.InteractionHandle);
 
             var identifyRequest = new IdxRequestPayload();
             identifyRequest.StateHandle = introspectResponse.StateHandle;

--- a/src/Okta.Idx.Sdk.UnitTests/IdxClientShould.cs
+++ b/src/Okta.Idx.Sdk.UnitTests/IdxClientShould.cs
@@ -229,8 +229,10 @@ namespace Okta.Idx.Sdk.UnitTests
 
             var mockRequestExecutor = new MockedStringRequestExecutor(rawResponse);
             var testClient = new TesteableIdxClient(mockRequestExecutor);
+            var mockIdxContext = new IdxContext("foo", "bar", "baz", "qux");
 
-            var response = await testClient.IntrospectAsync("foo");
+
+            var response = await testClient.IntrospectAsync(mockIdxContext);
             response.StateHandle.Should().NotBeNullOrEmpty();
             response.Version.Should().NotBeNullOrEmpty();
             response.ExpiresAt.Value.Should().Be(DateTimeOffset.Parse("2020-10-16T16:56:45.000Z"));

--- a/src/Okta.Idx.Sdk.UnitTests/MockedStringRequestExecutor.cs
+++ b/src/Okta.Idx.Sdk.UnitTests/MockedStringRequestExecutor.cs
@@ -12,6 +12,10 @@ namespace Okta.Idx.Sdk.UnitTests
         private readonly string _returnThis;
         private readonly int _statusCode;
 
+        public string ReceivedHref { get; set; }
+
+        public string ReceivedBody { get; set; }
+
         public string OktaDomain => throw new NotImplementedException();
 
         public MockedStringRequestExecutor(string returnThis, int statusCode = 200)
@@ -21,18 +25,25 @@ namespace Okta.Idx.Sdk.UnitTests
         }
 
         public Task<HttpResponse<string>> GetAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, CancellationToken cancellationToken)
-            => Task.FromResult(new HttpResponse<string>
+        {
+            ReceivedHref = href;
+            return Task.FromResult(new HttpResponse<string>
             {
                 StatusCode = _statusCode,
                 Payload = _returnThis,
             });
+        }
 
         public Task<HttpResponse<string>> PostAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, string body, CancellationToken cancellationToken)
-            => Task.FromResult(new HttpResponse<string>
+        {
+            ReceivedHref = href;
+            ReceivedBody = body;
+            return Task.FromResult(new HttpResponse<string>
             {
                 StatusCode = _statusCode,
                 Payload = _returnThis,
             });
+        }
 
         public Task<HttpResponse<string>> PutAsync(string href, IEnumerable<KeyValuePair<string, string>> headers, string body, CancellationToken cancellationToken)
         {

--- a/src/Okta.Idx.Sdk/IIdxClient.cs
+++ b/src/Okta.Idx.Sdk/IIdxClient.cs
@@ -13,18 +13,17 @@ namespace Okta.Idx.Sdk
     public interface IIdxClient : IOktaClient
     {
         /// <summary>
-        /// Calls the Idx introspect endpoint to get remediation steps. if Interaction Handle is
-        /// null, the SDK MUST make an API call to the interact endpoint to get the initial inteactionHandle.
+        /// Calls the Idx introspect endpoint to get remediation steps.
         /// </summary>
         /// <param name="idxContext">The IDX context that was returned by the `interact()` call</param>
         /// <returns>The IdxResponse.</returns>
         Task<IIdxResponse> IntrospectAsync(IIdxContext idxContext, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Calls the Idx interact endpoint to get an interaction handle.
+        /// Calls the Idx interact endpoint to get an IDX context.
         /// </summary>
         /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The Interaction Response.</returns>
+        /// <returns>The IDX context.</returns>
         Task<IIdxContext> InteractAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>

--- a/src/Okta.Idx.Sdk/IIdxClient.cs
+++ b/src/Okta.Idx.Sdk/IIdxClient.cs
@@ -16,9 +16,9 @@ namespace Okta.Idx.Sdk
         /// Calls the Idx introspect endpoint to get remediation steps. if Interaction Handle is
         /// null, the SDK MUST make an API call to the interact endpoint to get the initial inteactionHandle.
         /// </summary>
-        /// <param name="interactionHandle">The interaction handle that was returned by the `interact()` call</param>
+        /// <param name="idxContext">The IDX context that was returned by the `interact()` call</param>
         /// <returns>The IdxResponse.</returns>
-        Task<IIdxResponse> IntrospectAsync(string interactionHandle = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<IIdxResponse> IntrospectAsync(IIdxContext idxContext, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Calls the Idx interact endpoint to get an interaction handle.

--- a/src/Okta.Idx.Sdk/IIdxClient.cs
+++ b/src/Okta.Idx.Sdk/IIdxClient.cs
@@ -25,16 +25,11 @@ namespace Okta.Idx.Sdk
         /// </summary>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The Interaction Response.</returns>
-        Task<IInteractionHandleResponse> InteractAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task<IIdxContext> InteractAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Gets the client configuration.
         /// </summary>
         IdxConfiguration Configuration { get; }
-
-        /// <summary>
-        /// Gets the Idx client context.
-        /// </summary>
-        IIdxClientContext Context { get; }
     }
 }

--- a/src/Okta.Idx.Sdk/IIdxContext.cs
+++ b/src/Okta.Idx.Sdk/IIdxContext.cs
@@ -1,16 +1,18 @@
-﻿// <copyright file="IIdxClientContext.cs" company="Okta, Inc">
+﻿// <copyright file="IIdxContext.cs" company="Okta, Inc">
 // Copyright (c) 2020 - present Okta, Inc. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
 namespace Okta.Idx.Sdk
 {
-    public interface IIdxClientContext
+    public interface IIdxContext
     {
         string CodeVerifier { get; }
 
         string CodeChallenge { get; }
 
         string CodeChallengeMethod { get; }
+
+        string InteractionHandle { get; }
     }
 }

--- a/src/Okta.Idx.Sdk/IIdxSuccessResponse.cs
+++ b/src/Okta.Idx.Sdk/IIdxSuccessResponse.cs
@@ -40,7 +40,9 @@ namespace Okta.Idx.Sdk
         /// <summary>
         /// Exchange an interaction code for tokens.
         /// </summary>
-        /// <returns></returns>
-        Task<ITokenResponse> ExchangeCodeAsync(CancellationToken cancellationToken = default);
+        /// <param name="idxContext">The IDX context.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The tokens' reponse.</returns>
+        Task<ITokenResponse> ExchangeCodeAsync(IIdxContext idxContext, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Okta.Idx.Sdk/IdxClient.cs
+++ b/src/Okta.Idx.Sdk/IdxClient.cs
@@ -194,14 +194,15 @@ namespace Okta.Idx.Sdk
             return new IdxContext(codeVerifier, codeChallenge, codeChallengeMethod, response.InteractionHandle);
         }
 
+        // TODO: Idx Context? 
         /// <inheritdoc/>
         public async Task<IIdxResponse> IntrospectAsync(string interactionHandle = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (string.IsNullOrEmpty(interactionHandle))
             {
-                var interactResponse = await InteractAsync(cancellationToken);
+                var idxContext = await InteractAsync(cancellationToken);
 
-                interactionHandle = interactResponse.InteractionHandle;
+                interactionHandle = idxContext.InteractionHandle;
             }
 
             var payload = new IdxRequestPayload();

--- a/src/Okta.Idx.Sdk/IdxClient.cs
+++ b/src/Okta.Idx.Sdk/IdxClient.cs
@@ -195,17 +195,10 @@ namespace Okta.Idx.Sdk
         }
 
         /// <inheritdoc/>
-        public async Task<IIdxResponse> IntrospectAsync(string interactionHandle = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<IIdxResponse> IntrospectAsync(IIdxContext idxContext, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (string.IsNullOrEmpty(interactionHandle))
-            {
-                var idxContext = await InteractAsync(cancellationToken);
-
-                interactionHandle = idxContext.InteractionHandle;
-            }
-
             var payload = new IdxRequestPayload();
-            payload.SetProperty("interactionHandle", interactionHandle);
+            payload.SetProperty("interactionHandle", idxContext.InteractionHandle);
 
             var oktaDomain = UrlHelper.GetOktaRootUrl(this.Configuration.Issuer);
 

--- a/src/Okta.Idx.Sdk/IdxClient.cs
+++ b/src/Okta.Idx.Sdk/IdxClient.cs
@@ -194,7 +194,6 @@ namespace Okta.Idx.Sdk
             return new IdxContext(codeVerifier, codeChallenge, codeChallengeMethod, response.InteractionHandle);
         }
 
-        // TODO: Idx Context? 
         /// <inheritdoc/>
         public async Task<IIdxResponse> IntrospectAsync(string interactionHandle = null, CancellationToken cancellationToken = default(CancellationToken))
         {

--- a/src/Okta.Idx.Sdk/IdxContext.cs
+++ b/src/Okta.Idx.Sdk/IdxContext.cs
@@ -1,25 +1,26 @@
-﻿// <copyright file="IdxClientContext.cs" company="Okta, Inc">
+﻿// <copyright file="IdxContext.cs" company="Okta, Inc">
 // Copyright (c) 2020 - present Okta, Inc. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 // </copyright>
 
 namespace Okta.Idx.Sdk
 {
-    public class IdxClientContext : IIdxClientContext
+    public class IdxContext : IIdxContext
     {
         private readonly string _codeVerifier;
         private readonly string _codeChallenge;
         private readonly string _codeChallengeMethod;
-
-        public IdxClientContext()
+        private readonly string _interactionHandle;
+        public IdxContext()
         {
         }
 
-        public IdxClientContext(string codeVerifier, string codeChallenge, string codeChallengeMethod)
+        public IdxContext(string codeVerifier, string codeChallenge, string codeChallengeMethod, string interactionHandle)
         {
             _codeVerifier = codeVerifier;
             _codeChallenge = codeChallenge;
             _codeChallengeMethod = codeChallengeMethod;
+            _interactionHandle = interactionHandle;
         }
 
         public string CodeVerifier => _codeVerifier;
@@ -27,5 +28,7 @@ namespace Okta.Idx.Sdk
         public string CodeChallenge => _codeChallenge;
 
         public string CodeChallengeMethod => _codeChallengeMethod;
+
+        public string InteractionHandle => _interactionHandle;
     }
 }

--- a/src/Okta.Idx.Sdk/IdxSuccessResponse.cs
+++ b/src/Okta.Idx.Sdk/IdxSuccessResponse.cs
@@ -33,7 +33,7 @@ namespace Okta.Idx.Sdk
             return interactionCodeFormValue.GetProperty<string>("value");
         }
 
-        public async Task<ITokenResponse> ExchangeCodeAsync(CancellationToken cancellationToken = default)
+        public async Task<ITokenResponse> ExchangeCodeAsync(IIdxContext idxContext, CancellationToken cancellationToken = default)
         {
             var client = GetClient();
             var payload = new Dictionary<string, string>();
@@ -41,7 +41,7 @@ namespace Okta.Idx.Sdk
             payload.Add("grant_type", "interaction_code");
 
             // Add PKCE params
-            payload.Add("code_verifier", client.Context.CodeVerifier);
+            payload.Add("code_verifier", idxContext.CodeVerifier);
             payload.Add("client_id", client.Configuration.ClientId);
 
             if (client.Configuration.IsConfidentialClient)

--- a/src/Okta.Idx.Sdk/Resource.cs
+++ b/src/Okta.Idx.Sdk/Resource.cs
@@ -39,7 +39,7 @@ namespace Okta.Idx.Sdk
         /// <returns>The <see cref="IOktaClient">OktaClient</see> that created this resource.</returns>
         protected new IIdxClient GetClient()
         {
-            return (IIdxClient)_client ?? throw new InvalidOperationException("Only resources retrieved or saved through a Client object cna call server-side methods.");
+            return (IIdxClient)_client ?? throw new InvalidOperationException("Only resources retrieved or saved through a Client object can call server-side methods.");
         }
     }
 }

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="Cake" version="0.38.0" />
+</packages>


### PR DESCRIPTION
* Update the .NET IDX SDK to allow for continuing a flow from any point
* Create an immutable object of codeVerifier and InteractionHandle that can be used outside of the client. 
* Move the creation of codeVerifier into `interact` instead of client constructor
* Remove accessor of codeVerifier and Interactionhandle from the client
* Use new object in exchangeCode
* Update all ITs and UTs
* Update Readme