### PR TITLE
Allow passing an existing state when calling Interact()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,17 @@
 # Changelog
 
-## v0.1.0-beta01
+## v0.1.0-beta03
 
 ### Features
 
-- Initial version with basic functionality:
-* `InteractAsync()`
-* `IntrospectAsync()`
-* `CancelAsync()`
-* `RemediationOption.ProceedAsync()`
-* `IdxResponse.SuccessWithInteractionCode.ExchangeCode()`
+* Update `InteractAsync()` method to support passing an existing state
+* Expose the `state` in the `IdxContext`
 
 ## v0.1.0-beta02
 
 ### Features
 
-* Add support for password recovery.
+* Add support for password recovery
 * Update the client to allow for continuing a flow from any point
 * Move the creation of the PKCE codeVerifier into `InteractAsync()` instead of the client constructor
 
@@ -28,4 +24,15 @@
 ### Additions
 
 New models: `AuthenticatorEnrollment`, `AuthenticatorEnrollmentValue`, `Recover` and `AuthenticatorEnrollmentMethod`.
+
+## v0.1.0-beta01
+
+### Features
+
+- Initial version with basic functionality:
+* `InteractAsync()`
+* `IntrospectAsync()`
+* `CancelAsync()`
+* `RemediationOption.ProceedAsync()`
+* `IdxResponse.SuccessWithInteractionCode.ExchangeCode()`
 

--- a/src/Okta.Idx.Sdk.UnitTests/IdxClientShould.cs
+++ b/src/Okta.Idx.Sdk.UnitTests/IdxClientShould.cs
@@ -1,6 +1,5 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
-using Newtonsoft.Json;
 using Okta.Sdk.Abstractions;
 using System;
 using System.Linq;
@@ -24,6 +23,19 @@ namespace Okta.Idx.Sdk.UnitTests
             idxContext.CodeChallenge.Should().NotBeNullOrEmpty();
             idxContext.CodeChallengeMethod.Should().NotBeNullOrEmpty();
             idxContext.CodeVerifier.Should().NotBeNullOrEmpty();
+            idxContext.State.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact]
+        public async Task UseProvidedStateWhenCallingInteract()
+        {
+            var rawResponse = @"{ 'interaction_handle' : 'foo' }";
+            var mockRequestExecutor = new MockedStringRequestExecutor(rawResponse);
+            var testClient = new TesteableIdxClient(mockRequestExecutor);
+
+            var idxContext = await testClient.InteractAsync("bar");
+
+            idxContext.State.Should().Be("bar");
         }
 
         [Fact]
@@ -81,7 +93,7 @@ namespace Okta.Idx.Sdk.UnitTests
             var data = new DefaultSerializer().Deserialize(rawSuccessResponse);
             var successResponse = resourceFactory.CreateNew<IdxResponse>(data);
 
-            var mockIdxContext = new IdxContext("codeVer1f13r", "codeChanll3ng3", "S256", "foo");
+            var mockIdxContext = new IdxContext("codeVer1f13r", "codeChanll3ng3", "S256", "foo", "bar");
 
             var tokens = await successResponse.SuccessWithInteractionCode.ExchangeCodeAsync(mockIdxContext);
             mockRequestExecutor.ReceivedBody.Should().Contain($"\"code_verifier\":\"{mockIdxContext.CodeVerifier}\"");
@@ -319,7 +331,7 @@ namespace Okta.Idx.Sdk.UnitTests
             var data = new DefaultSerializer().Deserialize(rawSuccessResponse);
             var successResponse = resourceFactory.CreateNew<IdxResponse>(data);
 
-            var mockIdxContext = new IdxContext("codeVer1f13r", "codeChanll3ng3", "S256", "foo");
+            var mockIdxContext = new IdxContext("codeVer1f13r", "codeChanll3ng3", "S256", "foo", "bar");
 
             var tokens = await successResponse.SuccessWithInteractionCode.ExchangeCodeAsync(mockIdxContext);
 
@@ -406,7 +418,7 @@ namespace Okta.Idx.Sdk.UnitTests
 
             var mockRequestExecutor = new MockedStringRequestExecutor(rawResponse);
             var testClient = new TesteableIdxClient(mockRequestExecutor);
-            var mockIdxContext = new IdxContext("foo", "bar", "baz", "qux");
+            var mockIdxContext = new IdxContext("foo", "bar", "baz", "qux", "quux");
 
 
             var response = await testClient.IntrospectAsync(mockIdxContext);

--- a/src/Okta.Idx.Sdk/IIdxClient.cs
+++ b/src/Okta.Idx.Sdk/IIdxClient.cs
@@ -26,9 +26,10 @@ namespace Okta.Idx.Sdk
         /// <summary>
         /// Calls the Idx interact endpoint to get an IDX context.
         /// </summary>
-        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <param name="state">Optional value to use as the state argument when initiating the authentication flow. This is used to provide contextual information to survive redirects.</param>
+        /// <param name="cancellationToken">The cancellation token. Optional.</param>
         /// <returns>The IDX context.</returns>
-        Task<IIdxContext> InteractAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task<IIdxContext> InteractAsync(string state = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the client configuration.

--- a/src/Okta.Idx.Sdk/IIdxContext.cs
+++ b/src/Okta.Idx.Sdk/IIdxContext.cs
@@ -5,14 +5,34 @@
 
 namespace Okta.Idx.Sdk
 {
+    /// <summary>
+    /// An interface to represent the IDX context.
+    /// </summary>
     public interface IIdxContext
     {
+        /// <summary>
+        /// Gets the PKCE code verifier used during the interact call.
+        /// </summary>
         string CodeVerifier { get; }
 
+        /// <summary>
+        /// Gets the PKCE code challenge used during the interact call.
+        /// </summary>
         string CodeChallenge { get; }
 
+        /// <summary>
+        /// Gets the PKCE code challenge method used during the interact call.
+        /// </summary>
         string CodeChallengeMethod { get; }
 
+        /// <summary>
+        /// Gets the interaction handle obtained during the interact call.
+        /// </summary>
         string InteractionHandle { get; }
+
+        /// <summary>
+        /// Gets the state used during the interact call.
+        /// </summary>
+        string State { get; }
     }
 }

--- a/src/Okta.Idx.Sdk/IdxClient.cs
+++ b/src/Okta.Idx.Sdk/IdxClient.cs
@@ -165,10 +165,10 @@ namespace Okta.Idx.Sdk
         }
 
         /// <inheritdoc/>
-        public async Task<IIdxContext> InteractAsync(CancellationToken cancellationToken = default)
+        public async Task<IIdxContext> InteractAsync(string state = null, CancellationToken cancellationToken = default)
         {
             // PKCE props
-            var state = GenerateSecureRandomString(16);
+            state = state ?? GenerateSecureRandomString(16);
             var codeVerifier = GenerateSecureRandomString(86);
             var codeChallenge = GenerateCodeChallenge(codeVerifier, out var codeChallengeMethod);
 
@@ -195,7 +195,7 @@ namespace Okta.Idx.Sdk
             var response = await PostAsync<InteractionHandleResponse>(
                 request, cancellationToken).ConfigureAwait(false);
 
-            return new IdxContext(codeVerifier, codeChallenge, codeChallengeMethod, response.InteractionHandle);
+            return new IdxContext(codeVerifier, codeChallenge, codeChallengeMethod, response.InteractionHandle, state);
         }
 
         /// <inheritdoc/>

--- a/src/Okta.Idx.Sdk/IdxContext.cs
+++ b/src/Okta.Idx.Sdk/IdxContext.cs
@@ -14,6 +14,7 @@ namespace Okta.Idx.Sdk
         private readonly string _codeChallenge;
         private readonly string _codeChallengeMethod;
         private readonly string _interactionHandle;
+        private readonly string _state;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IdxContext"/> class.
@@ -29,12 +30,14 @@ namespace Okta.Idx.Sdk
         /// <param name="codeChallenge">The PKCE code challenge.</param>
         /// <param name="codeChallengeMethod">The PKCE code challenge method.</param>
         /// <param name="interactionHandle">The interaction handle.</param>
-        public IdxContext(string codeVerifier, string codeChallenge, string codeChallengeMethod, string interactionHandle)
+        /// <param name="state">The state.</param>
+        public IdxContext(string codeVerifier, string codeChallenge, string codeChallengeMethod, string interactionHandle, string state)
         {
             _codeVerifier = codeVerifier;
             _codeChallenge = codeChallenge;
             _codeChallengeMethod = codeChallengeMethod;
             _interactionHandle = interactionHandle;
+            _state = state;
         }
 
         /// <summary>
@@ -56,5 +59,10 @@ namespace Okta.Idx.Sdk
         /// Gets the interaction handle
         /// </summary>
         public string InteractionHandle => _interactionHandle;
+
+        /// <summary>
+        /// Gets the state
+        /// </summary>
+        public string State => _state;
     }
 }

--- a/src/Okta.Idx.Sdk/Okta.Idx.Sdk.csproj
+++ b/src/Okta.Idx.Sdk/Okta.Idx.Sdk.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
-    <Version>0.1.0-beta02</Version>
+    <Version>0.1.0-beta03</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Update Interact method to receive an optional `state` param, if it's not provided generate one.
* Expose the state property via IdxContext
* Update tests that verify the context
* Prepare a new release
* Fix OKTA-371119