### PR TITLE
Configuration support for both env vars and okta.yaml

### DIFF
--- a/src/Okta.Idx.Sdk/Extensions/StringExtensions.cs
+++ b/src/Okta.Idx.Sdk/Extensions/StringExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Okta.Idx.Sdk.Extensions
+{
+    public static class StringExtensions
+    {
+        public static List<string> ToList(this string stringParam,
+            char separator = ' ')
+        {
+            var listOfStrings = new List<string>();
+
+            if (!string.IsNullOrEmpty(stringParam))
+            {
+                listOfStrings = new List<string>(stringParam.Split(separator));
+            }
+
+            return listOfStrings;
+        }
+    }
+}

--- a/src/Okta.Idx.Sdk/IdxConfiguration.cs
+++ b/src/Okta.Idx.Sdk/IdxConfiguration.cs
@@ -21,9 +21,9 @@ namespace Okta.Idx.Sdk.Configuration
         public string ClientSecret { get; set; }
 
         /// <summary>
-        /// Gets or sets a list of string based scopes.
+        /// String that holds scopes.
         /// </summary>
-        public List<string> Scopes { get; set; } = OktaDefaults.Scopes;
+        public string Scopes { get; set; }
 
         /// <summary>
         /// Gets or sets the issuer.

--- a/src/Okta.Idx.Sdk/SignInWidgetAuthParams.cs
+++ b/src/Okta.Idx.Sdk/SignInWidgetAuthParams.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Okta.Idx.Sdk.Configuration;
+using Okta.Idx.Sdk.Extensions;
 
 namespace Okta.Idx.Sdk
 {
@@ -28,7 +29,7 @@ namespace Okta.Idx.Sdk
         public SignInWidgetAuthParams(IdxConfiguration idxConfiguration)
         {
             Issuer = idxConfiguration.Issuer;
-            Scopes = idxConfiguration.Scopes;
+            Scopes = idxConfiguration.Scopes.ToList();
         }
 
         /// <summary>

--- a/src/direct-auth-idx/direct-auth-idx/direct-auth-idx.csproj
+++ b/src/direct-auth-idx/direct-auth-idx/direct-auth-idx.csproj
@@ -354,6 +354,7 @@
     <Content Include="Views\Shared\_LogoutPartial.cshtml" />
     <Content Include="Views\Shared\Idps.cshtml" />
     <Content Include="Views\InteractionCode\Error.cshtml" />
+    <None Include="okta.yaml" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />

--- a/src/direct-auth-idx/direct-auth-idx/okta.yaml
+++ b/src/direct-auth-idx/direct-auth-idx/okta.yaml
@@ -1,0 +1,7 @@
+﻿okta:
+  idx:
+    issuer: "https://dev-86505495.okta.com/oauth2/default"
+    clientId: "0oatkejg9TPSHaDDA5d6"
+    clientSecret: "u1BdF9-m8JL0v0xs_SZyVPPEGXwfygrloEBzS_0l"
+    scopes: "openid profile offline_access"
+    redirectUri: "http://localhost:8080/authorization-code/callback"


### PR DESCRIPTION
This code adds support for environment variables and the okta.yaml.  For a description of the issue and fix see below:

**Issue:**
The scopes parameter was added to the okta.yaml file as a collection and in the environment variables as a string.  Example below:
_okta.yaml_

   scopes:
   - "openid"
   - "profile"
   - "offline_access"

_Env Variable:_ 
"openid profile offline_access"

The approach in this PR:

The approach in this PR was to make both configurations consistent and update the okta.yaml file to be as follows: 
scopes: "openid profile offline_access"

Any areas in the code that need the collection, the scopes are converted to a collection.

**Other approaches that can be taken:**

1. Use a different property name for the Env variable and okta.yaml (e.g. ScopesString for env variable and Scopes for okta.yaml)
2. Replace the FlexibleConfiguration library used to fetch configurations with another library or custom code and manually convert the environment variables string to a collection. This approach would be ideal in my opinion but would require more changes.


