### PR TITLE
Investigate windows build env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+os: windows
 language: csharp
 mono: latest
 dotnet: 5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 os: windows
 language: csharp
-mono: latest
+#mono: latest
 dotnet: 5.0
 before_install:
   - sudo apt-get install dotnet-sdk-3.1


### PR DESCRIPTION
https://docs.travis-ci.com/user/languages/csharp/#build-environment

> Currently, Travis builds your C#, F#, and Visual Basic project with the either the Mono or the .NET Core runtimes on Linux or macOS. Note that these runtimes do not implement the entire .NET framework, so Windows .NET framework programs may not be fully compatible and require porting.

Also there is no c# among the supported languages on the [Windows page](https://docs.travis-ci.com/user/reference/windows#supported-languages)

> Bash language: bash or language: shell
C with language: c
C++ with language: cpp
Go with language: go
Julia with language: julia
Node.js with language: node_js
Rust with language: rust