### PR TITLE
add project target `CopyRoslynFiles` to embeded-widget sample

### DIFF
--- a/samples/samples-aspnet/embedded-sign-in-widget/embedded-sign-in-widget/embedded-sign-in-widget.csproj
+++ b/samples/samples-aspnet/embedded-sign-in-widget/embedded-sign-in-widget/embedded-sign-in-widget.csproj
@@ -378,6 +378,13 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
+  <Target Name="CopyRoslynFiles" AfterTargets="AfterBuild" Condition="!$(Disable_CopyWebApplication) And '$(OutDir)' != '$(OutputPath)'">
+    <ItemGroup>
+      <RoslynFiles Include="$(CscToolPath)\*" />
+    </ItemGroup>
+    <MakeDir Directories="$(WebProjectOutputDir)\bin\roslyn" />
+    <Copy SourceFiles="@(RoslynFiles)" DestinationFolder="$(WebProjectOutputDir)\bin\roslyn" SkipUnchangedFiles="true" Retries="$(CopyRetryCount)" RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)" />
+</Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>


### PR DESCRIPTION
Added a target section to the embedded-widget-sample project to eliminate the error that may occur: `Could not find a part of the path '...\bin\roslyn\csc.exe'`