### PR TITLE
OKTA-411267: don't redirect to GET endpoint with state value

### DIFF
--- a/samples/samples-aspnet/embedded-sign-in-widget/embedded-sign-in-widget/AuthenticationHelper.cs
+++ b/samples/samples-aspnet/embedded-sign-in-widget/embedded-sign-in-widget/AuthenticationHelper.cs
@@ -19,29 +19,31 @@ namespace embedded_sign_in_widget
 
     public static class AuthenticationHelper
     {
+        public const string IdxStateKey = "IdxStateKey";
+
         public static async Task<ClaimsIdentity> GetIdentityFromTokenResponseAsync(IdxConfiguration configuration, ITokenResponse tokenResponse)
         {
             var claims = await GetClaimsFromUserInfoAsync(configuration, tokenResponse.AccessToken);
             claims = claims.Append(new Claim("access_token", tokenResponse.AccessToken));
             claims = claims.Append(new Claim("id_token", tokenResponse.IdToken));
-            if(!string.IsNullOrEmpty(tokenResponse.RefreshToken))
+            if (!string.IsNullOrEmpty(tokenResponse.RefreshToken))
             {
                 claims = claims.Append(new Claim("refresh_token", tokenResponse.RefreshToken));
-            }            
+            }
             ClaimsIdentity identity = new ClaimsIdentity(claims, DefaultAuthenticationTypes.ApplicationCookie);
 
             return identity;
         }
 
         public static async Task<IEnumerable<Claim>> GetClaimsFromUserInfoAsync(IdxConfiguration configuration, string accessToken)
-        { 
+        {
             Uri userInfoUri = new Uri(IdxUrlHelper.GetNormalizedUriString(configuration.Issuer, "v1/userinfo"));
             HttpClient httpClient = new HttpClient();
             var userInfoResponse = await httpClient.GetUserInfoAsync(new UserInfoRequest
-                                                                         {
-                                                                             Address = userInfoUri.ToString(),
-                                                                             Token = accessToken,
-                                                                         }).ConfigureAwait(false);
+            {
+                Address = userInfoUri.ToString(),
+                Token = accessToken,
+            }).ConfigureAwait(false);
             var nameClaim = new Claim(
                 ClaimTypes.Name,
                 userInfoResponse.Claims.FirstOrDefault(x => x.Type == "name")?.Value);
@@ -64,6 +66,7 @@ namespace embedded_sign_in_widget
                 signInWidgetConfiguration = widgetSignInResponse.SignInWidgetConfiguration;
             }
             session[idxContext.State] = idxContext;
+            session[IdxStateKey] = idxContext.State;
             return signInWidgetConfiguration;
         }
     }

--- a/samples/samples-aspnet/embedded-sign-in-widget/embedded-sign-in-widget/Controllers/AccountController.cs
+++ b/samples/samples-aspnet/embedded-sign-in-widget/embedded-sign-in-widget/Controllers/AccountController.cs
@@ -22,12 +22,11 @@ namespace embedded_sign_in_widget.Controllers
         [HttpGet]
         public async Task<ActionResult> SignInWidget(string state = null)
         {
-            SignInWidgetConfiguration signInWidgetConfiguration = await AuthenticationHelper.StartWidgetSignInAsync(HttpContext, _idxClient, state);
             if (string.IsNullOrEmpty(state))
             {
-                // redirect back to current action with state to allow reload without starting a new idx interaction
-                return Redirect($"/Account/SignInWidget?state={signInWidgetConfiguration.State}");
+                state = Session[AuthenticationHelper.IdxStateKey] as string;
             }
+            SignInWidgetConfiguration signInWidgetConfiguration = await AuthenticationHelper.StartWidgetSignInAsync(HttpContext, _idxClient, state);
             return View(signInWidgetConfiguration);
         }
 


### PR DESCRIPTION
- Added AuthenticationHelper.IdxStateKey, used as session key to retrieve state value.
- Set state value in session using: `session[IdxStateKey] = idxContext.State;`
- Updated state value handling logic