### PR TITLE
direct to Okta Verify authenticator method automatically if only one is available, bypassing selection

### DIFF
--- a/samples/samples-aspnet/embedded-auth-with-sdk/embedded-auth-with-sdk/Controllers/OktaVerifyController.cs
+++ b/samples/samples-aspnet/embedded-auth-with-sdk/embedded-auth-with-sdk/Controllers/OktaVerifyController.cs
@@ -20,10 +20,29 @@
             _idxClient = idxClient;
         }
 
-        public ActionResult SelectAuthenticatorMethod()
+        public async Task<ActionResult> SelectAuthenticatorMethod()
         {
             var model = (OktaVerifySelectAuthenticatorMethodModel)Session[nameof(OktaVerifySelectAuthenticatorMethodModel)];
 
+            if (model.MethodTypes?.Count == 1)
+            {
+                string methodType = model.MethodTypes[0];
+                var selectAuthenticatorOptions = new SelectOktaVerifyAuthenticatorOptions
+                {
+                    AuthenticatorMethodType = methodType,
+                    AuthenticatorId = model.AuthenticatorId,
+                };
+
+                var authnResponse = await _idxClient.SelectChallengeAuthenticatorAsync(selectAuthenticatorOptions, (IIdxContext)Session["IdxContext"]);
+
+                switch (methodType)
+                {
+                    case "totp":
+                        return View("EnterCode");
+                    case "push":
+                        return View("PushSent", new OktaVerifySelectAuthenticatorMethodModel());
+                }
+            }
             return View(model);
         }
 


### PR DESCRIPTION
If only one Okta Verify method is enabled (totp or push), this change removes the need to make a selection and automatically directs to the appropriate view.