### PR TITLE
OKTA-484760: reorder operations to fix e2e tests

### DIFF
--- a/samples/samples-aspnet/embedded-auth-with-sdk/Okta.Idx.Sdk.E2ETests/Features/10.1.4-5.TotpSupport.feature
+++ b/samples/samples-aspnet/embedded-auth-with-sdk/Okta.Idx.Sdk.E2ETests/Features/10.1.4-5.TotpSupport.feature
@@ -5,25 +5,26 @@
     And a user named "Mary"
     And Mary does not have an account in the org
 
-  @ignore
   Scenario: 10.1.4: Mary signs up for an account with Password, setups up required Google Authenticator by scanning a QR Code
     Given Mary navigates to the Self Service Registration View
     When she fills out her First Name
     And she fills out her Last Name
     And she fills out her Email
     And she submits the registration form
-    Then she sees the Select Authenticator page with password as the only option
+    Then she sees the Select Authenticator page
+
+    When she selects Email
+    Then she sees a page to input a code
+    When she inputs the correct code from her email
+
+    Then she sees a list of required factors to setup
+
     When she chooses password factor option
     And she submits the select authenticator form
     Then she sees the set new password form
     When she fills out her Password
     And she confirms her Password
     And she submits the change password form
-    Then she sees a list of required factors to setup
-
-	When she selects Email
-	Then she sees a page to input a code
-	When she inputs the correct code from her email
 
     When She selects Google Authenticator from the list
     And She scans a QR Code
@@ -32,39 +33,33 @@
     When She inputs the correct code from her Google Authenticator App
     And She selects Verify
     Then she sees the list of optional factors
-    #When She selects Email from the list
-    #Then she sees a page to input a code
-    #When she inputs the correct code from her email
-    #Then she sees the list of optional factors
+
     When she selects Skip
     Then she is redirected to the Root View
     And she sees a table with her profile info
     And the cell for the value of email is shown and contains her email
     And the cell for the value of name is shown and contains her first name and last name
   
-  @ignore
   Scenario: 10.1.5: Mary signs up for an account with Password, setups up required Google Authenticator by entering a shared secret
     Given Mary navigates to the Self Service Registration View
     When she fills out her First Name
     And she fills out her Last Name
     And she fills out her Email
     And she submits the registration form
-    Then she sees the Select Authenticator page with password as the only option
+    Then she sees the Select Authenticator page
+
+    When she selects Email
+    Then she sees a page to input a code
+    When she inputs the correct code from her email
+
+    Then she sees a list of required factors to setup
+
     When she chooses password factor option
     And she submits the select authenticator form
     Then she sees the set new password form
     When she fills out her Password
     And she confirms her Password
     And she submits the set new password form
-    Then she sees a list of required factors to setup
-
-
-
-	When she selects Email
-	Then she sees a page to input a code
-	When she inputs the correct code from her email
-
-
 
     When She selects Google Authenticator from the list
     And She enters the shared Secret Key into the Google Authenticator App
@@ -73,10 +68,7 @@
     When She inputs the correct code from her Google Authenticator App
     And She selects Verify
     Then she sees the list of optional factors
-    #When She selects Email from the list
-    #Then she sees a page to input a code
-    #When she inputs the correct code from her email
-    #Then she sees the list of optional factors
+
     When she selects Skip
     Then she is redirected to the Root View
     And she sees a table with her profile info

--- a/samples/samples-aspnet/embedded-auth-with-sdk/Okta.Idx.Sdk.E2ETests/Features/10.1.4-5.TotpSupport.feature.cs
+++ b/samples/samples-aspnet/embedded-auth-with-sdk/Okta.Idx.Sdk.E2ETests/Features/10.1.4-5.TotpSupport.feature.cs
@@ -97,18 +97,17 @@ namespace embedded_auth_with_sdk.E2ETests.Features
         }
         
         [Xunit.SkippableFactAttribute(DisplayName="10.1.4: Mary signs up for an account with Password, setups up required Google Aut" +
-            "henticator by scanning a QR Code", Skip="Ignored")]
+            "henticator by scanning a QR Code")]
         [Xunit.TraitAttribute("FeatureTitle", "10.1: TOTP Support (Google Authenticator) part 2")]
         [Xunit.TraitAttribute("Description", "10.1.4: Mary signs up for an account with Password, setups up required Google Aut" +
             "henticator by scanning a QR Code")]
         public virtual void _10_1_4MarySignsUpForAnAccountWithPasswordSetupsUpRequiredGoogleAuthenticatorByScanningAQRCode()
         {
-            string[] tagsOfScenario = new string[] {
-                    "ignore"};
+            string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("10.1.4: Mary signs up for an account with Password, setups up required Google Aut" +
                     "henticator by scanning a QR Code", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
-#line 9
+#line 8
   this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -131,88 +130,88 @@ namespace embedded_auth_with_sdk.E2ETests.Features
 #line 3
   this.FeatureBackground();
 #line hidden
-#line 10
+#line 9
     testRunner.Given("Mary navigates to the Self Service Registration View", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 11
+#line 10
     testRunner.When("she fills out her First Name", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 12
+#line 11
     testRunner.And("she fills out her Last Name", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 13
+#line 12
     testRunner.And("she fills out her Email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 14
+#line 13
     testRunner.And("she submits the registration form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 15
-    testRunner.Then("she sees the Select Authenticator page with password as the only option", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 14
+    testRunner.Then("she sees the Select Authenticator page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
 #line 16
-    testRunner.When("she chooses password factor option", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+    testRunner.When("she selects Email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
 #line 17
-    testRunner.And("she submits the select authenticator form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+    testRunner.Then("she sees a page to input a code", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
 #line 18
-    testRunner.Then("she sees the set new password form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line hidden
-#line 19
-    testRunner.When("she fills out her Password", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+    testRunner.When("she inputs the correct code from her email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
 #line 20
-    testRunner.And("she confirms her Password", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line hidden
-#line 21
-    testRunner.And("she submits the change password form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line hidden
-#line 22
     testRunner.Then("she sees a list of required factors to setup", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
+#line 22
+    testRunner.When("she chooses password factor option", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 23
+    testRunner.And("she submits the select authenticator form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
 #line 24
- testRunner.When("she selects Email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+    testRunner.Then("she sees the set new password form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
 #line 25
- testRunner.Then("she sees a page to input a code", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+    testRunner.When("she fills out her Password", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
 #line 26
- testRunner.When("she inputs the correct code from her email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+    testRunner.And("she confirms her Password", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 28
-    testRunner.When("She selects Google Authenticator from the list", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 27
+    testRunner.And("she submits the change password form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 29
-    testRunner.And("She scans a QR Code", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+    testRunner.When("She selects Google Authenticator from the list", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
 #line 30
-    testRunner.And("She selects Next", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+    testRunner.And("She scans a QR Code", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 31
-    testRunner.Then("the screen changes to receive an input for a TOTP code", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+    testRunner.And("She selects Next", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 32
-    testRunner.When("She inputs the correct code from her Google Authenticator App", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+    testRunner.Then("the screen changes to receive an input for a TOTP code", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
 #line 33
-    testRunner.And("She selects Verify", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+    testRunner.When("She inputs the correct code from her Google Authenticator App", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
 #line 34
+    testRunner.And("She selects Verify", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 35
     testRunner.Then("she sees the list of optional factors", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 39
+#line 37
     testRunner.When("she selects Skip", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 40
+#line 38
     testRunner.Then("she is redirected to the Root View", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 41
+#line 39
     testRunner.And("she sees a table with her profile info", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 42
+#line 40
     testRunner.And("the cell for the value of email is shown and contains her email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 43
+#line 41
     testRunner.And("the cell for the value of name is shown and contains her first name and last name" +
                         "", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
@@ -221,18 +220,17 @@ namespace embedded_auth_with_sdk.E2ETests.Features
         }
         
         [Xunit.SkippableFactAttribute(DisplayName="10.1.5: Mary signs up for an account with Password, setups up required Google Aut" +
-            "henticator by entering a shared secret", Skip="Ignored")]
+            "henticator by entering a shared secret")]
         [Xunit.TraitAttribute("FeatureTitle", "10.1: TOTP Support (Google Authenticator) part 2")]
         [Xunit.TraitAttribute("Description", "10.1.5: Mary signs up for an account with Password, setups up required Google Aut" +
             "henticator by entering a shared secret")]
         public virtual void _10_1_5MarySignsUpForAnAccountWithPasswordSetupsUpRequiredGoogleAuthenticatorByEnteringASharedSecret()
         {
-            string[] tagsOfScenario = new string[] {
-                    "ignore"};
+            string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("10.1.5: Mary signs up for an account with Password, setups up required Google Aut" +
                     "henticator by entering a shared secret", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
-#line 46
+#line 43
   this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -255,88 +253,88 @@ namespace embedded_auth_with_sdk.E2ETests.Features
 #line 3
   this.FeatureBackground();
 #line hidden
-#line 47
+#line 44
     testRunner.Given("Mary navigates to the Self Service Registration View", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 48
+#line 45
     testRunner.When("she fills out her First Name", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 49
+#line 46
     testRunner.And("she fills out her Last Name", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 50
+#line 47
     testRunner.And("she fills out her Email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 51
+#line 48
     testRunner.And("she submits the registration form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
+#line 49
+    testRunner.Then("she sees the Select Authenticator page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 51
+    testRunner.When("she selects Email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
 #line 52
-    testRunner.Then("she sees the Select Authenticator page with password as the only option", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+    testRunner.Then("she sees a page to input a code", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
 #line 53
-    testRunner.When("she chooses password factor option", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line hidden
-#line 54
-    testRunner.And("she submits the select authenticator form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+    testRunner.When("she inputs the correct code from her email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
 #line 55
-    testRunner.Then("she sees the set new password form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line hidden
-#line 56
-    testRunner.When("she fills out her Password", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line hidden
-#line 57
-    testRunner.And("she confirms her Password", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line hidden
-#line 58
-    testRunner.And("she submits the set new password form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line hidden
-#line 59
     testRunner.Then("she sees a list of required factors to setup", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 63
- testRunner.When("she selects Email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 57
+    testRunner.When("she chooses password factor option", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 58
+    testRunner.And("she submits the select authenticator form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 59
+    testRunner.Then("she sees the set new password form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 60
+    testRunner.When("she fills out her Password", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 61
+    testRunner.And("she confirms her Password", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 62
+    testRunner.And("she submits the set new password form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 64
- testRunner.Then("she sees a page to input a code", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line hidden
-#line 65
- testRunner.When("she inputs the correct code from her email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line hidden
-#line 69
     testRunner.When("She selects Google Authenticator from the list", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 70
+#line 65
     testRunner.And("She enters the shared Secret Key into the Google Authenticator App", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 71
+#line 66
     testRunner.And("She selects Next on the screen which is showing the QR code", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 72
+#line 67
     testRunner.Then("the screen changes to receive an input for a TOTP code", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 73
+#line 68
     testRunner.When("She inputs the correct code from her Google Authenticator App", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 74
+#line 69
     testRunner.And("She selects Verify", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 75
+#line 70
     testRunner.Then("she sees the list of optional factors", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 80
+#line 72
     testRunner.When("she selects Skip", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 81
+#line 73
     testRunner.Then("she is redirected to the Root View", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 82
+#line 74
     testRunner.And("she sees a table with her profile info", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 83
+#line 75
     testRunner.And("the cell for the value of email is shown and contains her email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 84
+#line 76
     testRunner.And("the cell for the value of name is shown and contains her first name and last name" +
                         "", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden

--- a/samples/samples-aspnet/embedded-auth-with-sdk/Okta.Idx.Sdk.E2ETests/Features/4-SsrWithEmailAndSms.feature
+++ b/samples/samples-aspnet/embedded-auth-with-sdk/Okta.Idx.Sdk.E2ETests/Features/4-SsrWithEmailAndSms.feature
@@ -8,46 +8,78 @@
 	And Mary does not have an account in the org
 
   @ignore
+  Scenario: 4.1.05: Mary signs up for an account with Password, setups up required Email factor, then skips optional SMS
+    Given The backend bug causing two verification emails is fixed
+    Given Mary navigates to the Self Service Registration View
+    When she fills out her First Name
+    And she fills out her Last Name
+    And she fills out her Email
+    And she submits the registration form
+    Then she sees the Select Authenticator page
+
+    When she chooses password factor option
+    And she submits the select authenticator form
+    Then she sees the set new password form
+    When she fills out her Password
+    And she confirms her Password
+    And she submits the change password form
+
+    Then she sees a list of required factors to setup
+
+    When she selects Email
+    Then she sees a page to input a code
+    When she inputs the correct code from her email
+
+    And she skips optional authenticators if prompted
+    Then she is redirected to the Root View
+    And an application session is created
+
   Scenario: 4.1.1: Mary signs up for an account with Password, setups up required Email factor, then skips optional SMS
 	Given Mary navigates to the Self Service Registration View
 	When she fills out her First Name
 	And she fills out her Last Name
 	And she fills out her Email
 	And she submits the registration form
-	Then she sees the Select Authenticator page with password as the only option
+	Then she sees the Select Authenticator page
+
+	When she selects Email
+	Then she sees a page to input a code
+	When she inputs the correct code from her email
+
+	Then she sees a list of required factors to setup
+
 	When she chooses password factor option
 	And she submits the select authenticator form
 	Then she sees the set new password form
 	When she fills out her Password
 	And she confirms her Password
 	And she submits the change password form
-	Then she sees a list of required factors to setup
-	When she selects Email
-	Then she sees a page to input a code
-	When she inputs the correct code from her email
-	Then she sees the list of optional factors (SMS)
-	When she selects Skip
+
+	And she skips optional authenticators if prompted
 	Then she is redirected to the Root View
     And an application session is created
 
-  @ignore
   Scenario: 4.1.2: Mary signs up for an account with Password, setups up required Email factor, And sets up optional SMS
 	Given Mary navigates to the Self Service Registration View
 	When she fills out her First Name
 	And she fills out her Last Name
 	And she fills out her Email
 	And she submits the registration form
-	Then she sees the Select Authenticator page with password as the only option
+	Then she sees the Select Authenticator page
+	
+	When she selects Email
+	Then she sees a page to input a code
+	When she inputs the correct code from her email
+
+	Then she sees a list of required factors to setup
+	
 	When she chooses password factor option
 	And she submits the select authenticator form
 	Then she sees the set new password form
 	When she fills out her Password
 	And she confirms her Password
 	And she submits the registration form
-	Then she sees a list of required factors to setup
-	When she selects Email
-	Then she sees a page to input a code
-	When she inputs the correct code from her email
+
 	Then she sees a list of factors to register
 	When she selects Phone from the list
 	And She inputs a valid phone number
@@ -68,25 +100,28 @@
 	Then she sees an error message "'Email' must be in the form of an email address"
 	And she sees an error message "Provided value for property 'Email' does not match required pattern"
   
-  @ignore
   Scenario: 4.1.4: Mary signs up for an account with Password, sets up required Email factor, And sets up optional SMS with an invalid phone number
 	Given Mary navigates to the Self Service Registration View
 	When she fills out her First Name
 	And she fills out her Last Name
 	And she fills out her Email
 	And she submits the registration form
-	Then she sees the Select Authenticator page with password as the only option
+	Then she sees the Select Authenticator page
+	
+	When she selects Email
+	Then she sees a page to input a code
+	When she inputs the correct code from her email
+	Then she sees a list of factors to register
+
+	Then she sees a list of required factors to setup
+
 	When she chooses password factor option
 	And she submits the select authenticator form
 	Then she sees the set new password form
 	When she fills out her Password
 	And she confirms her Password
 	And she submits the registration form
-	Then she sees a list of required factors to setup
-	When she selects Email
-	Then she sees a page to input a code
-	When she inputs the correct code from her email
-	Then she sees a list of factors to register
+
 	When she selects Phone from the list
 	And she inputs an invalid phone number
 	And submits the enrollment form

--- a/samples/samples-aspnet/embedded-auth-with-sdk/Okta.Idx.Sdk.E2ETests/Features/4-SsrWithEmailAndSms.feature.cs
+++ b/samples/samples-aspnet/embedded-auth-with-sdk/Okta.Idx.Sdk.E2ETests/Features/4-SsrWithEmailAndSms.feature.cs
@@ -105,18 +105,18 @@ namespace embedded_auth_with_sdk.E2ETests.Features
             this.TestTearDown();
         }
         
-        [Xunit.SkippableFactAttribute(DisplayName="4.1.1: Mary signs up for an account with Password, setups up required Email facto" +
-            "r, then skips optional SMS", Skip="Ignored")]
+        [Xunit.SkippableFactAttribute(DisplayName="4.1.05: Mary signs up for an account with Password, setups up required Email fact" +
+            "or, then skips optional SMS", Skip="Ignored")]
         [Xunit.TraitAttribute("FeatureTitle", "4.1: Self Service Registration with Email Activation and optional SMS")]
-        [Xunit.TraitAttribute("Description", "4.1.1: Mary signs up for an account with Password, setups up required Email facto" +
-            "r, then skips optional SMS")]
-        public virtual void _4_1_1MarySignsUpForAnAccountWithPasswordSetupsUpRequiredEmailFactorThenSkipsOptionalSMS()
+        [Xunit.TraitAttribute("Description", "4.1.05: Mary signs up for an account with Password, setups up required Email fact" +
+            "or, then skips optional SMS")]
+        public virtual void _4_1_05MarySignsUpForAnAccountWithPasswordSetupsUpRequiredEmailFactorThenSkipsOptionalSMS()
         {
             string[] tagsOfScenario = new string[] {
-                    "ignore"};
+                    "Ignore"};
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("4.1.1: Mary signs up for an account with Password, setups up required Email facto" +
-                    "r, then skips optional SMS", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("4.1.05: Mary signs up for an account with Password, setups up required Email fact" +
+                    "or, then skips optional SMS", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
 #line 11
   this.ScenarioInitialize(scenarioInfo);
 #line hidden
@@ -141,82 +141,81 @@ namespace embedded_auth_with_sdk.E2ETests.Features
   this.FeatureBackground();
 #line hidden
 #line 12
- testRunner.Given("Mary navigates to the Self Service Registration View", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+    testRunner.Given("The backend bug causing two verification emails is fixed", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
 #line 13
- testRunner.When("she fills out her First Name", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+ testRunner.Given("Mary navigates to the Self Service Registration View", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
 #line 14
- testRunner.And("she fills out her Last Name", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.When("she fills out her First Name", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
 #line 15
- testRunner.And("she fills out her Email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.And("she fills out her Last Name", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 16
- testRunner.And("she submits the registration form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.And("she fills out her Email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 17
- testRunner.Then("she sees the Select Authenticator page with password as the only option", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+ testRunner.And("she submits the registration form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 18
- testRunner.When("she chooses password factor option", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line hidden
-#line 19
- testRunner.And("she submits the select authenticator form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.Then("she sees the Select Authenticator page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
 #line 20
- testRunner.Then("she sees the set new password form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+ testRunner.When("she chooses password factor option", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
 #line 21
- testRunner.When("she fills out her Password", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+ testRunner.And("she submits the select authenticator form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 22
- testRunner.And("she confirms her Password", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.Then("she sees the set new password form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
 #line 23
- testRunner.And("she submits the change password form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.When("she fills out her Password", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
 #line 24
- testRunner.Then("she sees a list of required factors to setup", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+ testRunner.And("she confirms her Password", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 25
- testRunner.When("she selects Email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line hidden
-#line 26
- testRunner.Then("she sees a page to input a code", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+ testRunner.And("she submits the change password form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 27
- testRunner.When("she inputs the correct code from her email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line hidden
-#line 28
- testRunner.Then("she sees the list of optional factors (SMS)", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+ testRunner.Then("she sees a list of required factors to setup", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
 #line 29
- testRunner.When("she selects Skip", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+ testRunner.When("she selects Email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
 #line 30
- testRunner.Then("she is redirected to the Root View", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+ testRunner.Then("she sees a page to input a code", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
 #line 31
+ testRunner.When("she inputs the correct code from her email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 33
+ testRunner.And("she skips optional authenticators if prompted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 34
+ testRunner.Then("she is redirected to the Root View", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 35
     testRunner.And("an application session is created", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             }
             this.ScenarioCleanup();
         }
         
-        [Xunit.SkippableFactAttribute(DisplayName="4.1.2: Mary signs up for an account with Password, setups up required Email facto" +
-            "r, And sets up optional SMS", Skip="Ignored")]
+        [Xunit.SkippableFactAttribute(DisplayName="4.1.1: Mary signs up for an account with Password, setups up required Email facto" +
+            "r, then skips optional SMS")]
         [Xunit.TraitAttribute("FeatureTitle", "4.1: Self Service Registration with Email Activation and optional SMS")]
-        [Xunit.TraitAttribute("Description", "4.1.2: Mary signs up for an account with Password, setups up required Email facto" +
-            "r, And sets up optional SMS")]
-        public virtual void _4_1_2MarySignsUpForAnAccountWithPasswordSetupsUpRequiredEmailFactorAndSetsUpOptionalSMS()
+        [Xunit.TraitAttribute("Description", "4.1.1: Mary signs up for an account with Password, setups up required Email facto" +
+            "r, then skips optional SMS")]
+        public virtual void _4_1_1MarySignsUpForAnAccountWithPasswordSetupsUpRequiredEmailFactorThenSkipsOptionalSMS()
         {
-            string[] tagsOfScenario = new string[] {
-                    "ignore"};
+            string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("4.1.2: Mary signs up for an account with Password, setups up required Email facto" +
-                    "r, And sets up optional SMS", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
-#line 34
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("4.1.1: Mary signs up for an account with Password, setups up required Email facto" +
+                    "r, then skips optional SMS", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
+#line 37
   this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -239,74 +238,53 @@ namespace embedded_auth_with_sdk.E2ETests.Features
 #line 3
   this.FeatureBackground();
 #line hidden
-#line 35
+#line 38
  testRunner.Given("Mary navigates to the Self Service Registration View", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 36
+#line 39
  testRunner.When("she fills out her First Name", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 37
+#line 40
  testRunner.And("she fills out her Last Name", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 38
+#line 41
  testRunner.And("she fills out her Email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 39
- testRunner.And("she submits the registration form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line hidden
-#line 40
- testRunner.Then("she sees the Select Authenticator page with password as the only option", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line hidden
-#line 41
- testRunner.When("she chooses password factor option", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line hidden
 #line 42
- testRunner.And("she submits the select authenticator form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.And("she submits the registration form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 43
- testRunner.Then("she sees the set new password form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line hidden
-#line 44
- testRunner.When("she fills out her Password", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+ testRunner.Then("she sees the Select Authenticator page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
 #line 45
- testRunner.And("she confirms her Password", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line hidden
-#line 46
- testRunner.And("she submits the registration form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line hidden
-#line 47
- testRunner.Then("she sees a list of required factors to setup", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line hidden
-#line 48
  testRunner.When("she selects Email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 49
+#line 46
  testRunner.Then("she sees a page to input a code", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 50
+#line 47
  testRunner.When("she inputs the correct code from her email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
+#line 49
+ testRunner.Then("she sees a list of required factors to setup", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
 #line 51
- testRunner.Then("she sees a list of factors to register", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+ testRunner.When("she chooses password factor option", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
 #line 52
- testRunner.When("she selects Phone from the list", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+ testRunner.And("she submits the select authenticator form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 53
- testRunner.And("She inputs a valid phone number", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.Then("she sees the set new password form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
 #line 54
- testRunner.And("She selects \"Receive a Code\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.When("she fills out her Password", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
 #line 55
- testRunner.Then("the screen changes to receive an input for a code", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+ testRunner.And("she confirms her Password", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 56
- testRunner.When("She inputs the correct code from her SMS", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line hidden
-#line 57
- testRunner.And("She selects \"Verify\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.And("she submits the change password form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 58
  testRunner.And("she skips optional authenticators if prompted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
@@ -321,14 +299,17 @@ namespace embedded_auth_with_sdk.E2ETests.Features
             this.ScenarioCleanup();
         }
         
-        [Xunit.SkippableFactAttribute(DisplayName="4.1.3: Mary signs up with an invalid Email")]
+        [Xunit.SkippableFactAttribute(DisplayName="4.1.2: Mary signs up for an account with Password, setups up required Email facto" +
+            "r, And sets up optional SMS")]
         [Xunit.TraitAttribute("FeatureTitle", "4.1: Self Service Registration with Email Activation and optional SMS")]
-        [Xunit.TraitAttribute("Description", "4.1.3: Mary signs up with an invalid Email")]
-        public virtual void _4_1_3MarySignsUpWithAnInvalidEmail()
+        [Xunit.TraitAttribute("Description", "4.1.2: Mary signs up for an account with Password, setups up required Email facto" +
+            "r, And sets up optional SMS")]
+        public virtual void _4_1_2MarySignsUpForAnAccountWithPasswordSetupsUpRequiredEmailFactorAndSetsUpOptionalSMS()
         {
             string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("4.1.3: Mary signs up with an invalid Email", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("4.1.2: Mary signs up for an account with Password, setups up required Email facto" +
+                    "r, And sets up optional SMS", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
 #line 62
   this.ScenarioInitialize(scenarioInfo);
 #line hidden
@@ -362,35 +343,87 @@ namespace embedded_auth_with_sdk.E2ETests.Features
  testRunner.And("she fills out her Last Name", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 66
- testRunner.And("she fills out her Email with an invalid email format", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.And("she fills out her Email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 67
  testRunner.And("she submits the registration form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
 #line 68
- testRunner.Then("she sees an error message \"\'Email\' must be in the form of an email address\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+ testRunner.Then("she sees the Select Authenticator page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 69
- testRunner.And("she sees an error message \"Provided value for property \'Email\' does not match req" +
-                        "uired pattern\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 70
+ testRunner.When("she selects Email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 71
+ testRunner.Then("she sees a page to input a code", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 72
+ testRunner.When("she inputs the correct code from her email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 74
+ testRunner.Then("she sees a list of required factors to setup", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 76
+ testRunner.When("she chooses password factor option", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 77
+ testRunner.And("she submits the select authenticator form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 78
+ testRunner.Then("she sees the set new password form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 79
+ testRunner.When("she fills out her Password", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 80
+ testRunner.And("she confirms her Password", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 81
+ testRunner.And("she submits the registration form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 83
+ testRunner.Then("she sees a list of factors to register", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 84
+ testRunner.When("she selects Phone from the list", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 85
+ testRunner.And("She inputs a valid phone number", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 86
+ testRunner.And("She selects \"Receive a Code\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 87
+ testRunner.Then("the screen changes to receive an input for a code", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 88
+ testRunner.When("She inputs the correct code from her SMS", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 89
+ testRunner.And("She selects \"Verify\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 90
+ testRunner.And("she skips optional authenticators if prompted", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 91
+ testRunner.Then("she is redirected to the Root View", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 92
+    testRunner.And("an application session is created", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             }
             this.ScenarioCleanup();
         }
         
-        [Xunit.SkippableFactAttribute(DisplayName="4.1.4: Mary signs up for an account with Password, sets up required Email factor," +
-            " And sets up optional SMS with an invalid phone number", Skip="Ignored")]
+        [Xunit.SkippableFactAttribute(DisplayName="4.1.3: Mary signs up with an invalid Email")]
         [Xunit.TraitAttribute("FeatureTitle", "4.1: Self Service Registration with Email Activation and optional SMS")]
-        [Xunit.TraitAttribute("Description", "4.1.4: Mary signs up for an account with Password, sets up required Email factor," +
-            " And sets up optional SMS with an invalid phone number")]
-        public virtual void _4_1_4MarySignsUpForAnAccountWithPasswordSetsUpRequiredEmailFactorAndSetsUpOptionalSMSWithAnInvalidPhoneNumber()
+        [Xunit.TraitAttribute("Description", "4.1.3: Mary signs up with an invalid Email")]
+        public virtual void _4_1_3MarySignsUpWithAnInvalidEmail()
         {
-            string[] tagsOfScenario = new string[] {
-                    "ignore"};
+            string[] tagsOfScenario = ((string[])(null));
             System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("4.1.4: Mary signs up for an account with Password, sets up required Email factor," +
-                    " And sets up optional SMS with an invalid phone number", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
-#line 72
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("4.1.3: Mary signs up with an invalid Email", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
+#line 94
   this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -413,67 +446,127 @@ namespace embedded_auth_with_sdk.E2ETests.Features
 #line 3
   this.FeatureBackground();
 #line hidden
-#line 73
+#line 95
  testRunner.Given("Mary navigates to the Self Service Registration View", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 74
+#line 96
  testRunner.When("she fills out her First Name", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 75
+#line 97
  testRunner.And("she fills out her Last Name", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 76
+#line 98
+ testRunner.And("she fills out her Email with an invalid email format", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 99
+ testRunner.And("she submits the registration form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 100
+ testRunner.Then("she sees an error message \"\'Email\' must be in the form of an email address\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 101
+ testRunner.And("she sees an error message \"Provided value for property \'Email\' does not match req" +
+                        "uired pattern\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            }
+            this.ScenarioCleanup();
+        }
+        
+        [Xunit.SkippableFactAttribute(DisplayName="4.1.4: Mary signs up for an account with Password, sets up required Email factor," +
+            " And sets up optional SMS with an invalid phone number")]
+        [Xunit.TraitAttribute("FeatureTitle", "4.1: Self Service Registration with Email Activation and optional SMS")]
+        [Xunit.TraitAttribute("Description", "4.1.4: Mary signs up for an account with Password, sets up required Email factor," +
+            " And sets up optional SMS with an invalid phone number")]
+        public virtual void _4_1_4MarySignsUpForAnAccountWithPasswordSetsUpRequiredEmailFactorAndSetsUpOptionalSMSWithAnInvalidPhoneNumber()
+        {
+            string[] tagsOfScenario = ((string[])(null));
+            System.Collections.Specialized.OrderedDictionary argumentsOfScenario = new System.Collections.Specialized.OrderedDictionary();
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("4.1.4: Mary signs up for an account with Password, sets up required Email factor," +
+                    " And sets up optional SMS with an invalid phone number", null, tagsOfScenario, argumentsOfScenario, this._featureTags);
+#line 103
+  this.ScenarioInitialize(scenarioInfo);
+#line hidden
+            bool isScenarioIgnored = default(bool);
+            bool isFeatureIgnored = default(bool);
+            if ((tagsOfScenario != null))
+            {
+                isScenarioIgnored = tagsOfScenario.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((this._featureTags != null))
+            {
+                isFeatureIgnored = this._featureTags.Where(__entry => __entry != null).Where(__entry => String.Equals(__entry, "ignore", StringComparison.CurrentCultureIgnoreCase)).Any();
+            }
+            if ((isScenarioIgnored || isFeatureIgnored))
+            {
+                testRunner.SkipScenario();
+            }
+            else
+            {
+                this.ScenarioStart();
+#line 3
+  this.FeatureBackground();
+#line hidden
+#line 104
+ testRunner.Given("Mary navigates to the Self Service Registration View", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line hidden
+#line 105
+ testRunner.When("she fills out her First Name", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 106
+ testRunner.And("she fills out her Last Name", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 107
  testRunner.And("she fills out her Email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 77
+#line 108
  testRunner.And("she submits the registration form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 78
- testRunner.Then("she sees the Select Authenticator page with password as the only option", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 109
+ testRunner.Then("she sees the Select Authenticator page", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 79
- testRunner.When("she chooses password factor option", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line hidden
-#line 80
- testRunner.And("she submits the select authenticator form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line hidden
-#line 81
- testRunner.Then("she sees the set new password form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line hidden
-#line 82
- testRunner.When("she fills out her Password", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line hidden
-#line 83
- testRunner.And("she confirms her Password", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line hidden
-#line 84
- testRunner.And("she submits the registration form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line hidden
-#line 85
- testRunner.Then("she sees a list of required factors to setup", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line hidden
-#line 86
+#line 111
  testRunner.When("she selects Email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 87
+#line 112
  testRunner.Then("she sees a page to input a code", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 88
+#line 113
  testRunner.When("she inputs the correct code from her email", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 89
+#line 114
  testRunner.Then("she sees a list of factors to register", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
-#line 90
+#line 116
+ testRunner.Then("she sees a list of required factors to setup", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 118
+ testRunner.When("she chooses password factor option", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 119
+ testRunner.And("she submits the select authenticator form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 120
+ testRunner.Then("she sees the set new password form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line hidden
+#line 121
+ testRunner.When("she fills out her Password", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line hidden
+#line 122
+ testRunner.And("she confirms her Password", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 123
+ testRunner.And("she submits the registration form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+#line 125
  testRunner.When("she selects Phone from the list", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
 #line hidden
-#line 91
+#line 126
  testRunner.And("she inputs an invalid phone number", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 92
+#line 127
  testRunner.And("submits the enrollment form", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 93
+#line 128
  testRunner.Then("she should see an error message \"Unable to initiate factor enrollment: Invalid Ph" +
                         "one Number.\"", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden

--- a/samples/samples-aspnet/embedded-auth-with-sdk/Okta.Idx.Sdk.E2ETests/Steps/Pages/SelectAuthenticatorPageSteps.cs
+++ b/samples/samples-aspnet/embedded-auth-with-sdk/Okta.Idx.Sdk.E2ETests/Steps/Pages/SelectAuthenticatorPageSteps.cs
@@ -91,6 +91,7 @@ namespace embedded_auth_with_sdk.E2ETests.Steps.Pages
             _selectAuthenticatorPageModel.SubmitButton.Click();
         }
 
+        [Then(@"she sees the Select Authenticator page")]
         [Then(@"she sees the Select Authenticator page with password as the only option")]
         [Then(@"she sees the Select Authenticator page")]
         public void ThenSheSeesTheSelectAuthenticatorPageWithPasswordAsAnOnlyOption()


### PR DESCRIPTION
- Created PR in response to [OKTA-484760](https://oktainc.atlassian.net/browse/OKTA-484760) - _**.Net OIE > Investigate 5 ignored e2e tests**_
- Changes aren't necessary when this is resolved [OKTA-493964](https://oktainc.atlassian.net/browse/OKTA-493964) - _**2 verification emails received if password authenticator enrolled before email authenticator**_
- Update branch or create a new one to address [OKTA-494283](https://oktainc.atlassian.net/browse/OKTA-494283) - _**.NET OIE > re-enable ignored tests**_ 