### PR TITLE
OKTA-523367: send push notification accounting for unchecked "send push automatically" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.2.4
+
+### Bug Fixes
+
+* Fix Okta Verify push notification not sent if "send push automatically" is unchecked.
+
+## 2.2.3
+
+### Features
+
+* Added support for login_hint and ACR values.
+
 ## 2.2.2
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ The user needs to select and challenge an additional authenticator to continue w
 
 There other statuses that you can get when calling other methods of the `IdxClient`:
 
+#### Awaiting for challenge authenticator poll response
+
+Type: `AwaitingChallengeAuthenticatorPollResponse`
+
+The user needs to acknowledge the pushe request sent by Okta Verify.
+
 #### Awaiting for Authenticator Verification
 
 Type: `AwaitingAuthenticatorVerification`

--- a/samples/samples-aspnet/embedded-auth-with-sdk/embedded-auth-with-sdk.sln
+++ b/samples/samples-aspnet/embedded-auth-with-sdk/embedded-auth-with-sdk.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30711.63
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32819.101
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "embedded-auth-with-sdk", "embedded-auth-with-sdk\embedded-auth-with-sdk.csproj", "{88504747-10B6-425F-B27D-66426F7ED199}"
 EndProject

--- a/samples/samples-aspnet/embedded-auth-with-sdk/embedded-auth-with-sdk/Controllers/OktaVerifyController.cs
+++ b/samples/samples-aspnet/embedded-auth-with-sdk/embedded-auth-with-sdk/Controllers/OktaVerifyController.cs
@@ -186,10 +186,6 @@
                             return View("PushSent", model);
                     }
                 }
-                else
-                {
-                    return RedirectToAction("VerifyAuthenticator", "Manage");
-                }
             }
             catch (Exception e)
             {

--- a/samples/samples-aspnet/embedded-auth-with-sdk/embedded-auth-with-sdk/Controllers/OktaVerifyController.cs
+++ b/samples/samples-aspnet/embedded-auth-with-sdk/embedded-auth-with-sdk/Controllers/OktaVerifyController.cs
@@ -175,7 +175,8 @@
                 var authnResponse = await _idxClient.SelectChallengeAuthenticatorAsync(selectAuthenticatorOptions,
                     (IIdxContext)Session["IdxContext"]);
 
-                if (authnResponse.AuthenticationStatus == AuthenticationStatus.AwaitingAuthenticatorVerification)
+                if (authnResponse.AuthenticationStatus == AuthenticationStatus.AwaitingAuthenticatorVerification ||
+                    authnResponse.AuthenticationStatus == AuthenticationStatus.AwaitingChallengePollResponse)
                 {
                     switch (model.MethodType)
                     {
@@ -184,6 +185,10 @@
                         case "push":
                             return View("PushSent", model);
                     }
+                }
+                else
+                {
+                    return RedirectToAction("VerifyAuthenticator", "Manage");
                 }
             }
             catch (Exception e)

--- a/samples/samples-aspnet/embedded-auth-with-sdk/embedded-auth-with-sdk/Controllers/OktaVerifyController.cs
+++ b/samples/samples-aspnet/embedded-auth-with-sdk/embedded-auth-with-sdk/Controllers/OktaVerifyController.cs
@@ -176,7 +176,7 @@
                     (IIdxContext)Session["IdxContext"]);
 
                 if (authnResponse.AuthenticationStatus == AuthenticationStatus.AwaitingAuthenticatorVerification ||
-                    authnResponse.AuthenticationStatus == AuthenticationStatus.AwaitingChallengePollResponse)
+                    authnResponse.AuthenticationStatus == AuthenticationStatus.AwaitingChallengeAuthenticatorPollResponse)
                 {
                     switch (model.MethodType)
                     {

--- a/src/Okta.Idx.Sdk.UnitTests/IdxClientShould.cs
+++ b/src/Okta.Idx.Sdk.UnitTests/IdxClientShould.cs
@@ -16278,6 +16278,774 @@ namespace Okta.Idx.Sdk.UnitTests
             securityQuestionEnrollResponse.CurrentAuthenticator.ContextualData.Questions.Should().HaveCount(19);
         }
 
+        [Fact]
+        public async Task ProceedWithOktaVerifyPush()
+        {
+            var idxContext = Substitute.For<IIdxContext>();
+            #region mock responses
+            var introspectResponse = @"{
+    ""version"": ""1.0.0"",
+    ""stateHandle"": ""02.id.tJMobed3RY5uohKURnea8XiYDOospIHu9_tUatsz"",
+    ""expiresAt"": ""2022-12-01T14:08:27.000Z"",
+    ""intent"": ""LOGIN"",
+    ""remediation"": {
+        ""type"": ""array"",
+        ""value"": [
+            {
+                ""rel"": [
+                    ""create-form""
+                ],
+                ""name"": ""authenticator-verification-data"",
+                ""relatesTo"": [
+                    ""$.currentAuthenticator""
+                ],
+                ""href"": ""https://test.org/idp/idx/challenge"",
+                ""method"": ""POST"",
+                ""produces"": ""application/ion+json; okta-version=1.0.0"",
+                ""value"": [
+                    {
+                        ""name"": ""authenticator"",
+                        ""label"": ""Okta Verify"",
+                        ""form"": {
+                            ""value"": [
+                                {
+                                    ""name"": ""id"",
+                                    ""required"": true,
+                                    ""value"": ""aut2xo0xj4LK7Fupb5d7"",
+                                    ""mutable"": false
+                                },
+                                {
+                                    ""name"": ""methodType"",
+                                    ""type"": ""string"",
+                                    ""required"": true,
+                                    ""options"": [
+                                        {
+                                            ""label"": ""Enter a code"",
+                                            ""value"": ""totp""
+                                        },
+                                        {
+                                            ""label"": ""Get a push notification"",
+                                            ""value"": ""push""
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        ""name"": ""stateHandle"",
+                        ""required"": true,
+                        ""value"": ""02.id.tJMobed3RY5uohKURnea8XiYDOospIHu9_tUatsz"",
+                        ""visible"": false,
+                        ""mutable"": false
+                    }
+                ],
+                ""accepts"": ""application/json; okta-version=1.0.0""
+            },
+            {
+                ""rel"": [
+                    ""create-form""
+                ],
+                ""name"": ""select-authenticator-authenticate"",
+                ""href"": ""https://test.org/idp/idx/challenge"",
+                ""method"": ""POST"",
+                ""produces"": ""application/ion+json; okta-version=1.0.0"",
+                ""value"": [
+                    {
+                        ""name"": ""authenticator"",
+                        ""type"": ""object"",
+                        ""options"": [
+                            {
+                                ""label"": ""Okta Verify"",
+                                ""value"": {
+                                    ""form"": {
+                                        ""value"": [
+                                            {
+                                                ""name"": ""id"",
+                                                ""required"": true,
+                                                ""value"": ""aut2xo0xj4LK7Fupb5d7"",
+                                                ""mutable"": false
+                                            },
+                                            {
+                                                ""name"": ""methodType"",
+                                                ""type"": ""string"",
+                                                ""required"": false,
+                                                ""options"": [
+                                                    {
+                                                        ""label"": ""Enter a code"",
+                                                        ""value"": ""totp""
+                                                    },
+                                                    {
+                                                        ""label"": ""Get a push notification"",
+                                                        ""value"": ""push""
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                ""relatesTo"": ""$.authenticators.value[0]""
+                            }
+                        ]
+                    },
+                    {
+                        ""name"": ""stateHandle"",
+                        ""required"": true,
+                        ""value"": ""02.id.tJMobed3RY5uohKURnea8XiYDOospIHu9_tUatsz"",
+                        ""visible"": false,
+                        ""mutable"": false
+                    }
+                ],
+                ""accepts"": ""application/json; okta-version=1.0.0""
+            }
+        ]
+    },
+    ""currentAuthenticator"": {
+        ""type"": ""object"",
+        ""value"": {
+            ""type"": ""app"",
+            ""key"": ""okta_verify"",
+            ""id"": ""aut2xo0xj4LK7Fupb5d7"",
+            ""displayName"": ""Okta Verify"",
+            ""methods"": [
+                {
+                    ""type"": ""push""
+                },
+                {
+                    ""type"": ""totp""
+                }
+            ]
+        }
+    },
+    ""authenticators"": {
+        ""type"": ""array"",
+        ""value"": [
+            {
+                ""type"": ""app"",
+                ""key"": ""okta_verify"",
+                ""id"": ""aut2xo0xj4LK7Fupb5d7"",
+                ""displayName"": ""Okta Verify"",
+                ""methods"": [
+                    {
+                        ""type"": ""push""
+                    },
+                    {
+                        ""type"": ""totp""
+                    }
+                ],
+                ""allowedFor"": ""any""
+            }
+        ]
+    },
+    ""authenticatorEnrollments"": {
+        ""type"": ""array"",
+        ""value"": [
+            {
+                ""profile"": {
+                    ""deviceName"": ""Galaxy Z Fold3 5G""
+                },
+                ""type"": ""app"",
+                ""key"": ""okta_verify"",
+                ""id"": ""pfd7gxyytl0yP3uMR5d7"",
+                ""displayName"": ""Okta Verify"",
+                ""methods"": [
+                    {
+                        ""type"": ""push""
+                    },
+                    {
+                        ""type"": ""totp""
+                    }
+                ]
+            }
+        ]
+    },
+    ""user"": {
+        ""type"": ""object"",
+        ""value"": {
+            ""id"": ""00u2xoipvjOIR19225d7"",
+            ""identifier"": ""user@email.com"",
+            ""profile"": {
+                ""firstName"": ""Bryan"",
+                ""lastName"": ""Apellanes"",
+                ""timeZone"": ""America/Los_Angeles"",
+                ""locale"": ""en_US""
+            }
+        }
+    },
+    ""cancel"": {
+        ""rel"": [
+            ""create-form""
+        ],
+        ""name"": ""cancel"",
+        ""href"": ""https://test.org/idp/idx/cancel"",
+        ""method"": ""POST"",
+        ""produces"": ""application/ion+json; okta-version=1.0.0"",
+        ""value"": [
+            {
+                ""name"": ""stateHandle"",
+                ""required"": true,
+                ""value"": ""02.id.tJMobed3RY5uohKURnea8XiYDOospIHu9_tUatsz"",
+                ""visible"": false,
+                ""mutable"": false
+            }
+        ],
+        ""accepts"": ""application/json; okta-version=1.0.0""
+    },
+    ""app"": {
+        ""type"": ""object"",
+        ""value"": {
+            ""name"": ""oidc_client"",
+            ""label"": ""Okta Verify Web App"",
+            ""id"": ""0oa2zrtjg7kdBZ9aG5d7""
+        }
+    },
+    ""authentication"": {
+        ""type"": ""object"",
+        ""value"": {
+            ""protocol"": ""OAUTH2.0"",
+            ""issuer"": {
+                ""id"": ""aus2xo0xe0oJtPzIS5d7"",
+                ""name"": ""default"",
+                ""uri"": ""https://test.org/oauth2/default""
+            },
+            ""request"": {
+                ""max_age"": -1,
+                ""scope"": ""openid profile offline_access"",
+                ""response_type"": ""code"",
+                ""redirect_uri"": ""http://localhost:44314/interactioncode/callback"",
+                ""state"": ""XkTQQBirTnnuD_JB8d2IEw"",
+                ""code_challenge_method"": ""S256"",
+                ""code_challenge"": ""luxCCyaGyq1MmP-NHTxWKCxm3rJdHBHyYiOs-KrkIdM"",
+                ""response_mode"": ""query""
+            }
+        }
+    }
+}";
+            var selectAuthenticatorResponse = @"{
+    ""version"": ""1.0.0"",
+    ""stateHandle"": ""02.id.tJMobed3RY5uohKURnea8XiYDOospIHu9_tUatsz"",
+    ""expiresAt"": ""2022-12-01T14:11:43.000Z"",
+    ""intent"": ""LOGIN"",
+    ""remediation"": {
+        ""type"": ""array"",
+        ""value"": [
+            {
+                ""rel"": [
+                    ""create-form""
+                ],
+                ""name"": ""authenticator-verification-data"",
+                ""relatesTo"": [
+                    ""$.currentAuthenticator""
+                ],
+                ""href"": ""https://test.org/idp/idx/challenge"",
+                ""method"": ""POST"",
+                ""produces"": ""application/ion+json; okta-version=1.0.0"",
+                ""value"": [
+                    {
+                        ""name"": ""authenticator"",
+                        ""label"": ""Okta Verify"",
+                        ""form"": {
+                            ""value"": [
+                                {
+                                    ""name"": ""id"",
+                                    ""required"": true,
+                                    ""value"": ""aut2xo0xj4LK7Fupb5d7"",
+                                    ""mutable"": false
+                                },
+                                {
+                                    ""name"": ""methodType"",
+                                    ""type"": ""string"",
+                                    ""required"": true,
+                                    ""options"": [
+                                        {
+                                            ""label"": ""Get a push notification"",
+                                            ""value"": ""push""
+                                        }
+                                    ]
+                                },
+                                {
+                                    ""name"": ""autoChallenge"",
+                                    ""type"": ""boolean"",
+                                    ""label"": ""Send push automatically"",
+                                    ""required"": false,
+                                    ""value"": false,
+                                    ""mutable"": true
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        ""name"": ""stateHandle"",
+                        ""required"": true,
+                        ""value"": ""02.id.tJMobed3RY5uohKURnea8XiYDOospIHu9_tUatsz"",
+                        ""visible"": false,
+                        ""mutable"": false
+                    }
+                ],
+                ""accepts"": ""application/json; okta-version=1.0.0""
+            },
+            {
+                ""rel"": [
+                    ""create-form""
+                ],
+                ""name"": ""select-authenticator-authenticate"",
+                ""href"": ""https://test.org/idp/idx/challenge"",
+                ""method"": ""POST"",
+                ""produces"": ""application/ion+json; okta-version=1.0.0"",
+                ""value"": [
+                    {
+                        ""name"": ""authenticator"",
+                        ""type"": ""object"",
+                        ""options"": [
+                            {
+                                ""label"": ""Okta Verify"",
+                                ""value"": {
+                                    ""form"": {
+                                        ""value"": [
+                                            {
+                                                ""name"": ""id"",
+                                                ""required"": true,
+                                                ""value"": ""aut2xo0xj4LK7Fupb5d7"",
+                                                ""mutable"": false
+                                            },
+                                            {
+                                                ""name"": ""methodType"",
+                                                ""type"": ""string"",
+                                                ""required"": false,
+                                                ""options"": [
+                                                    {
+                                                        ""label"": ""Enter a code"",
+                                                        ""value"": ""totp""
+                                                    },
+                                                    {
+                                                        ""label"": ""Get a push notification"",
+                                                        ""value"": ""push""
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                ""relatesTo"": ""$.authenticators.value[0]""
+                            }
+                        ]
+                    },
+                    {
+                        ""name"": ""stateHandle"",
+                        ""required"": true,
+                        ""value"": ""02.id.tJMobed3RY5uohKURnea8XiYDOospIHu9_tUatsz"",
+                        ""visible"": false,
+                        ""mutable"": false
+                    }
+                ],
+                ""accepts"": ""application/json; okta-version=1.0.0""
+            }
+        ]
+    },
+    ""currentAuthenticator"": {
+        ""type"": ""object"",
+        ""value"": {
+            ""resend"": {
+                ""rel"": [
+                    ""create-form""
+                ],
+                ""name"": ""resend"",
+                ""href"": ""https://test.org/idp/idx/challenge/resend"",
+                ""method"": ""POST"",
+                ""produces"": ""application/ion+json; okta-version=1.0.0"",
+                ""value"": [
+                    {
+                        ""name"": ""stateHandle"",
+                        ""required"": true,
+                        ""value"": ""02.id.tJMobed3RY5uohKURnea8XiYDOospIHu9_tUatsz"",
+                        ""visible"": false,
+                        ""mutable"": false
+                    }
+                ],
+                ""accepts"": ""application/json; okta-version=1.0.0""
+            },
+            ""type"": ""app"",
+            ""key"": ""okta_verify"",
+            ""id"": ""aut2xo0xj4LK7Fupb5d7"",
+            ""displayName"": ""Okta Verify"",
+            ""methods"": [
+                {
+                    ""type"": ""push""
+                }
+            ]
+        }
+    },
+    ""authenticators"": {
+        ""type"": ""array"",
+        ""value"": [
+            {
+                ""type"": ""app"",
+                ""key"": ""okta_verify"",
+                ""id"": ""aut2xo0xj4LK7Fupb5d7"",
+                ""displayName"": ""Okta Verify"",
+                ""methods"": [
+                    {
+                        ""type"": ""push""
+                    },
+                    {
+                        ""type"": ""totp""
+                    }
+                ],
+                ""allowedFor"": ""any""
+            }
+        ]
+    },
+    ""authenticatorEnrollments"": {
+        ""type"": ""array"",
+        ""value"": [
+            {
+                ""profile"": {
+                    ""deviceName"": ""Galaxy Z Fold3 5G""
+                },
+                ""type"": ""app"",
+                ""key"": ""okta_verify"",
+                ""id"": ""pfd7gxyytl0yP3uMR5d7"",
+                ""displayName"": ""Okta Verify"",
+                ""methods"": [
+                    {
+                        ""type"": ""push""
+                    },
+                    {
+                        ""type"": ""totp""
+                    }
+                ]
+            }
+        ]
+    },
+    ""user"": {
+        ""type"": ""object"",
+        ""value"": {
+            ""id"": ""00u2xoipvjOIR19225d7"",
+            ""identifier"": ""user@email.com"",
+            ""profile"": {
+                ""firstName"": ""Bryan"",
+                ""lastName"": ""Apellanes"",
+                ""timeZone"": ""America/Los_Angeles"",
+                ""locale"": ""en_US""
+            }
+        }
+    },
+    ""cancel"": {
+        ""rel"": [
+            ""create-form""
+        ],
+        ""name"": ""cancel"",
+        ""href"": ""https://test.org/idp/idx/cancel"",
+        ""method"": ""POST"",
+        ""produces"": ""application/ion+json; okta-version=1.0.0"",
+        ""value"": [
+            {
+                ""name"": ""stateHandle"",
+                ""required"": true,
+                ""value"": ""02.id.tJMobed3RY5uohKURnea8XiYDOospIHu9_tUatsz"",
+                ""visible"": false,
+                ""mutable"": false
+            }
+        ],
+        ""accepts"": ""application/json; okta-version=1.0.0""
+    },
+    ""app"": {
+        ""type"": ""object"",
+        ""value"": {
+            ""name"": ""oidc_client"",
+            ""label"": ""Okta Verify Web App"",
+            ""id"": ""0oa2zrtjg7kdBZ9aG5d7""
+        }
+    },
+    ""authentication"": {
+        ""type"": ""object"",
+        ""value"": {
+            ""protocol"": ""OAUTH2.0"",
+            ""issuer"": {
+                ""id"": ""aus2xo0xe0oJtPzIS5d7"",
+                ""name"": ""default"",
+                ""uri"": ""https://test.org/oauth2/default""
+            },
+            ""request"": {
+                ""max_age"": -1,
+                ""scope"": ""openid profile offline_access"",
+                ""response_type"": ""code"",
+                ""redirect_uri"": ""http://localhost:44314/interactioncode/callback"",
+                ""state"": ""XkTQQBirTnnuD_JB8d2IEw"",
+                ""code_challenge_method"": ""S256"",
+                ""code_challenge"": ""luxCCyaGyq1MmP-NHTxWKCxm3rJdHBHyYiOs-KrkIdM"",
+                ""response_mode"": ""query""
+            }
+        }
+    }
+}";
+            var pushRequestResponse = @"{
+    ""version"": ""1.0.0"",
+    ""stateHandle"": ""02.id.tJMobed3RY5uohKURnea8XiYDOospIHu9_tUatsz"",
+    ""expiresAt"": ""2022-12-01T14:12:28.000Z"",
+    ""intent"": ""LOGIN"",
+    ""remediation"": {
+        ""type"": ""array"",
+        ""value"": [
+            {
+                ""rel"": [
+                    ""create-form""
+                ],
+                ""name"": ""challenge-poll"",
+                ""relatesTo"": [
+                    ""$.currentAuthenticator""
+                ],
+                ""href"": ""https://test.org/idp/idx/authenticators/poll"",
+                ""method"": ""POST"",
+                ""produces"": ""application/ion+json; okta-version=1.0.0"",
+                ""refresh"": 4000,
+                ""value"": [
+                    {
+                        ""name"": ""autoChallenge"",
+                        ""type"": ""boolean"",
+                        ""label"": ""Send push automatically"",
+                        ""required"": false,
+                        ""value"": false,
+                        ""mutable"": true
+                    },
+                    {
+                        ""name"": ""stateHandle"",
+                        ""required"": true,
+                        ""value"": ""02.id.tJMobed3RY5uohKURnea8XiYDOospIHu9_tUatsz"",
+                        ""visible"": false,
+                        ""mutable"": false
+                    }
+                ],
+                ""accepts"": ""application/json; okta-version=1.0.0""
+            },
+            {
+                ""rel"": [
+                    ""create-form""
+                ],
+                ""name"": ""select-authenticator-authenticate"",
+                ""href"": ""https://test.org/idp/idx/challenge"",
+                ""method"": ""POST"",
+                ""produces"": ""application/ion+json; okta-version=1.0.0"",
+                ""value"": [
+                    {
+                        ""name"": ""authenticator"",
+                        ""type"": ""object"",
+                        ""options"": [
+                            {
+                                ""label"": ""Okta Verify"",
+                                ""value"": {
+                                    ""form"": {
+                                        ""value"": [
+                                            {
+                                                ""name"": ""id"",
+                                                ""required"": true,
+                                                ""value"": ""aut2xo0xj4LK7Fupb5d7"",
+                                                ""mutable"": false
+                                            },
+                                            {
+                                                ""name"": ""methodType"",
+                                                ""type"": ""string"",
+                                                ""required"": false,
+                                                ""options"": [
+                                                    {
+                                                        ""label"": ""Enter a code"",
+                                                        ""value"": ""totp""
+                                                    },
+                                                    {
+                                                        ""label"": ""Get a push notification"",
+                                                        ""value"": ""push""
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                ""relatesTo"": ""$.authenticators.value[0]""
+                            }
+                        ]
+                    },
+                    {
+                        ""name"": ""stateHandle"",
+                        ""required"": true,
+                        ""value"": ""02.id.tJMobed3RY5uohKURnea8XiYDOospIHu9_tUatsz"",
+                        ""visible"": false,
+                        ""mutable"": false
+                    }
+                ],
+                ""accepts"": ""application/json; okta-version=1.0.0""
+            }
+        ]
+    },
+    ""currentAuthenticator"": {
+        ""type"": ""object"",
+        ""value"": {
+            ""resend"": {
+                ""rel"": [
+                    ""create-form""
+                ],
+                ""name"": ""resend"",
+                ""href"": ""https://test.org/idp/idx/challenge"",
+                ""method"": ""POST"",
+                ""produces"": ""application/ion+json; okta-version=1.0.0"",
+                ""value"": [
+                    {
+                        ""name"": ""authenticator"",
+                        ""required"": true,
+                        ""value"": {
+                            ""methodType"": ""push"",
+                            ""id"": ""aut2xo0xj4LK7Fupb5d7""
+                        },
+                        ""visible"": false,
+                        ""mutable"": false
+                    },
+                    {
+                        ""name"": ""stateHandle"",
+                        ""required"": true,
+                        ""value"": ""02.id.tJMobed3RY5uohKURnea8XiYDOospIHu9_tUatsz"",
+                        ""visible"": false,
+                        ""mutable"": false
+                    }
+                ],
+                ""accepts"": ""application/json; okta-version=1.0.0""
+            },
+            ""type"": ""app"",
+            ""key"": ""okta_verify"",
+            ""id"": ""aut2xo0xj4LK7Fupb5d7"",
+            ""displayName"": ""Okta Verify"",
+            ""methods"": [
+                {
+                    ""type"": ""push""
+                }
+            ]
+        }
+    },
+    ""authenticators"": {
+        ""type"": ""array"",
+        ""value"": [
+            {
+                ""type"": ""app"",
+                ""key"": ""okta_verify"",
+                ""id"": ""aut2xo0xj4LK7Fupb5d7"",
+                ""displayName"": ""Okta Verify"",
+                ""methods"": [
+                    {
+                        ""type"": ""push""
+                    },
+                    {
+                        ""type"": ""totp""
+                    }
+                ],
+                ""allowedFor"": ""any""
+            }
+        ]
+    },
+    ""authenticatorEnrollments"": {
+        ""type"": ""array"",
+        ""value"": [
+            {
+                ""profile"": {
+                    ""deviceName"": ""Galaxy Z Fold3 5G""
+                },
+                ""type"": ""app"",
+                ""key"": ""okta_verify"",
+                ""id"": ""pfd7gxyytl0yP3uMR5d7"",
+                ""displayName"": ""Okta Verify"",
+                ""methods"": [
+                    {
+                        ""type"": ""push""
+                    },
+                    {
+                        ""type"": ""totp""
+                    }
+                ]
+            }
+        ]
+    },
+    ""user"": {
+        ""type"": ""object"",
+        ""value"": {
+            ""id"": ""00u2xoipvjOIR19225d7"",
+            ""identifier"": ""user@email.com"",
+            ""profile"": {
+                ""firstName"": ""Bryan"",
+                ""lastName"": ""Apellanes"",
+                ""timeZone"": ""America/Los_Angeles"",
+                ""locale"": ""en_US""
+            }
+        }
+    },
+    ""cancel"": {
+        ""rel"": [
+            ""create-form""
+        ],
+        ""name"": ""cancel"",
+        ""href"": ""https://test.org/idp/idx/cancel"",
+        ""method"": ""POST"",
+        ""produces"": ""application/ion+json; okta-version=1.0.0"",
+        ""value"": [
+            {
+                ""name"": ""stateHandle"",
+                ""required"": true,
+                ""value"": ""02.id.tJMobed3RY5uohKURnea8XiYDOospIHu9_tUatsz"",
+                ""visible"": false,
+                ""mutable"": false
+            }
+        ],
+        ""accepts"": ""application/json; okta-version=1.0.0""
+    },
+    ""app"": {
+        ""type"": ""object"",
+        ""value"": {
+            ""name"": ""oidc_client"",
+            ""label"": ""Okta Verify Web App"",
+            ""id"": ""0oa2zrtjg7kdBZ9aG5d7""
+        }
+    },
+    ""authentication"": {
+        ""type"": ""object"",
+        ""value"": {
+            ""protocol"": ""OAUTH2.0"",
+            ""issuer"": {
+                ""id"": ""aus2xo0xe0oJtPzIS5d7"",
+                ""name"": ""default"",
+                ""uri"": ""https://test.org/oauth2/default""
+            },
+            ""request"": {
+                ""max_age"": -1,
+                ""scope"": ""openid profile offline_access"",
+                ""response_type"": ""code"",
+                ""redirect_uri"": ""http://localhost:44314/interactioncode/callback"",
+                ""state"": ""XkTQQBirTnnuD_JB8d2IEw"",
+                ""code_challenge_method"": ""S256"",
+                ""code_challenge"": ""luxCCyaGyq1MmP-NHTxWKCxm3rJdHBHyYiOs-KrkIdM"",
+                ""response_mode"": ""query""
+            }
+        }
+    }
+}";
+            #endregion
+            Queue<MockResponse> queue = new Queue<MockResponse>();
+            queue.Enqueue(new MockResponse { StatusCode = 200, Response = introspectResponse });
+            queue.Enqueue(new MockResponse { StatusCode = 200, Response = selectAuthenticatorResponse });
+            queue.Enqueue(new MockResponse { StatusCode = 200, Response = pushRequestResponse });
+
+            var mockRequestExecutor = new MockedQueueRequestExecutor(queue);
+            var testClient = new TesteableIdxClient(mockRequestExecutor);
+
+            var oktaOptions = new SelectOktaVerifyAuthenticatorOptions
+            {
+                AuthenticatorMethodType = AuthenticatorMethodType.Push,
+                AuthenticatorId = "aut2xo0xj4LK7Fupb5d7"
+            };
+
+            var response = await testClient.SelectChallengeAuthenticatorAsync(oktaOptions, idxContext);
+            queue.Count.Should().Be(0);
+            response.Should().NotBeNull();
+            response.AuthenticationStatus.Should().Be(AuthenticationStatus.AwaitingChallengePollResponse);
+            response.CurrentAuthenticator.Should().NotBeNull();
+            response.CurrentAuthenticator.Name.Should().Be("Okta Verify");
+        }
+
         #endregion
     }
 }

--- a/src/Okta.Idx.Sdk.UnitTests/IdxClientShould.cs
+++ b/src/Okta.Idx.Sdk.UnitTests/IdxClientShould.cs
@@ -17041,7 +17041,7 @@ namespace Okta.Idx.Sdk.UnitTests
             var response = await testClient.SelectChallengeAuthenticatorAsync(oktaOptions, idxContext);
             queue.Count.Should().Be(0);
             response.Should().NotBeNull();
-            response.AuthenticationStatus.Should().Be(AuthenticationStatus.AwaitingChallengePollResponse);
+            response.AuthenticationStatus.Should().Be(AuthenticationStatus.AwaitingChallengeAuthenticatorPollResponse);
             response.CurrentAuthenticator.Should().NotBeNull();
             response.CurrentAuthenticator.Name.Should().Be("Okta Verify");
         }

--- a/src/Okta.Idx.Sdk/AuthenticationStatus.cs
+++ b/src/Okta.Idx.Sdk/AuthenticationStatus.cs
@@ -58,7 +58,7 @@ namespace Okta.Idx.Sdk
         /// <summary>
         /// Waiting for push notification response.
         /// </summary>
-        AwaitingChallengePollResponse,
+        AwaitingChallengeAuthenticatorPollResponse,
 
         /// <summary>
         /// Okta Verify push challenge rejected.

--- a/src/Okta.Idx.Sdk/AuthenticationStatus.cs
+++ b/src/Okta.Idx.Sdk/AuthenticationStatus.cs
@@ -56,6 +56,11 @@ namespace Okta.Idx.Sdk
         AwaitingChallengeAuthenticatorSelection,
 
         /// <summary>
+        /// Waiting for push notification response.
+        /// </summary>
+        AwaitingChallengePollResponse,
+
+        /// <summary>
         /// Okta Verify push challenge rejected.
         /// </summary>
         PushChallengeFailed,

--- a/src/Okta.Idx.Sdk/IdxClient.cs
+++ b/src/Okta.Idx.Sdk/IdxClient.cs
@@ -1794,14 +1794,14 @@ namespace Okta.Idx.Sdk
                 idxRequestPayload,
                 cancellationToken);
 
-            var status = selectAuthenticatorResponse.ContainsRemediationOption(RemediationType.ChallengePoll) ? AuthenticationStatus.AwaitingChallengePollResponse : AuthenticationStatus.AwaitingAuthenticatorVerification;
+            var status = selectAuthenticatorResponse.ContainsRemediationOption(RemediationType.ChallengePoll) ? AuthenticationStatus.AwaitingChallengeAuthenticatorPollResponse : AuthenticationStatus.AwaitingAuthenticatorVerification;
             if (challengeAuthenticatorOptions.AuthenticatorMethodType == AuthenticatorMethodType.Push & status == AuthenticationStatus.AwaitingAuthenticatorVerification)
             {
                 var challengePayload = new IdxRequestPayload();
                 challengePayload.SetProperty("stateHandle", selectAuthenticatorResponse.StateHandle);
                 challengePayload.SetProperty("authenticator", new { id = challengeAuthenticatorOptions.AuthenticatorId, methodType = challengeAuthenticatorOptions.AuthenticatorMethodType, autoChallenge = "false" });
                 selectAuthenticatorResponse = await selectAuthenticatorResponse.ProceedWithRemediationOptionAsync(RemediationType.AuthenticatorVerificationData, challengePayload, cancellationToken);
-                status = AuthenticationStatus.AwaitingChallengePollResponse;
+                status = AuthenticationStatus.AwaitingChallengeAuthenticatorPollResponse;
             }
 
             return CreateAuthenticationResponse(idxContext, selectAuthenticatorResponse, status);

--- a/src/Okta.Idx.Sdk/IdxClient.cs
+++ b/src/Okta.Idx.Sdk/IdxClient.cs
@@ -210,12 +210,20 @@ namespace Okta.Idx.Sdk
 
         private static AuthenticationResponse CreateAuthenticationResponse(IIdxContext idxContext, IIdxResponse idxResponse, AuthenticationStatus authenticationStatus)
         {
+            if (idxContext == null)
+            {
+                throw new ArgumentNullException("idxContext");
+            }
+            if (idxResponse == null)
+            {
+                throw new ArgumentNullException("idxResponse");
+            }
             return new AuthenticationResponse
             {
                 IdxContext = idxContext,
                 AuthenticationStatus = authenticationStatus,
-                Authenticators = IdxResponseHelper.ConvertToAuthenticators(idxResponse.Authenticators.Value),
-                CurrentAuthenticator = IdxResponseHelper.ConvertToAuthenticator(idxResponse.Authenticators.Value, idxResponse.CurrentAuthenticator.Value),                
+                Authenticators = idxResponse.Authenticators?.Value == null ? null :  IdxResponseHelper.ConvertToAuthenticators(idxResponse.Authenticators.Value),
+                CurrentAuthenticator = idxResponse.CurrentAuthenticator?.Value == null ? null : IdxResponseHelper.ConvertToAuthenticator(idxResponse.Authenticators.Value, idxResponse.CurrentAuthenticator?.Value),                
                 CanSkip = idxResponse.ContainsRemediationOption(RemediationType.Skip),
             };
         }

--- a/src/Okta.Idx.Sdk/IdxClient.cs
+++ b/src/Okta.Idx.Sdk/IdxClient.cs
@@ -2038,7 +2038,5 @@ namespace Okta.Idx.Sdk
                 IsPasswordRequired = IsRemediationRequireCredentials("identify", introspectResponse),
             };
         }
-
-        
     }
 }

--- a/src/Okta.Idx.Sdk/IdxClient.cs
+++ b/src/Okta.Idx.Sdk/IdxClient.cs
@@ -212,18 +212,20 @@ namespace Okta.Idx.Sdk
         {
             if (idxContext == null)
             {
-                throw new ArgumentNullException("idxContext");
+                throw new ArgumentNullException(nameof(idxContext));
             }
+
             if (idxResponse == null)
             {
-                throw new ArgumentNullException("idxResponse");
+                throw new ArgumentNullException(nameof(idxResponse));
             }
+
             return new AuthenticationResponse
             {
                 IdxContext = idxContext,
                 AuthenticationStatus = authenticationStatus,
-                Authenticators = idxResponse.Authenticators?.Value == null ? null :  IdxResponseHelper.ConvertToAuthenticators(idxResponse.Authenticators.Value),
-                CurrentAuthenticator = idxResponse.CurrentAuthenticator?.Value == null ? null : IdxResponseHelper.ConvertToAuthenticator(idxResponse.Authenticators.Value, idxResponse.CurrentAuthenticator?.Value),                
+                Authenticators = idxResponse.Authenticators?.Value == null ? null : IdxResponseHelper.ConvertToAuthenticators(idxResponse.Authenticators.Value),
+                CurrentAuthenticator = idxResponse.CurrentAuthenticator?.Value == null ? null : IdxResponseHelper.ConvertToAuthenticator(idxResponse.Authenticators.Value, idxResponse.CurrentAuthenticator?.Value),
                 CanSkip = idxResponse.ContainsRemediationOption(RemediationType.Skip),
             };
         }

--- a/src/Okta.Idx.Sdk/Okta.Idx.Sdk.csproj
+++ b/src/Okta.Idx.Sdk/Okta.Idx.Sdk.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
-    <Version>2.2.3</Version>
+    <Version>2.2.4</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
If someone unchecks the box labeled "send push automatically" when logging in using Okta Verify, the Sdk does not account for the change in responses from the server and the push request is never sent.  This fix accounts for whether this option is checked and sends the push in either case.
 
Fixes #173 