### PR TITLE
Fix build to use newer dotnet tools 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
                 name: "Pack test package"
                 command: |
                   $Env:githash = git rev-parse --short HEAD 
-                  dotnet pack ./src/Okta.Idx.Sdk/Okta.Idx.Sdk.csproj --version-suffix $Env:githash --output ./artifacts
+                  dotnet pack ./src/Okta.Idx.Sdk/Okta.Idx.Sdk.csproj --configuration release --version-suffix $Env:githash --output ./artifacts
             - general-platform-helpers/step-artifacts-prepare-and-upload-windows:
                 files-to-upload: "artifacts"
                 location: "com/okta/devex/okta-idx-dotnet"
@@ -39,6 +39,10 @@ jobs:
           condition:
             equal: [ "<<pipeline.git.branch>>", "master" ]
           steps:
+            - run:
+                name: "Pack release package"
+                command: |
+                  dotnet pack ./src/Okta.Idx.Sdk/Okta.Idx.Sdk.csproj --configuration release --output ./artifacts
             - general-platform-helpers/step-artifacts-prepare-and-upload-windows:
                 files-to-upload: "artifacts"
                 location: "com/okta/devex/okta-idx-dotnet"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,9 @@ jobs:
           steps:
             - run:
                 name: "Pack test package"
-                  command: |
-                    $Env:githash = git rev-parse --short HEAD 
-                    dotnet pack ./src/Okta.Idx.Sdk/Okta.Idx.Sdk.csproj --version-suffix $Env:githash --output ./artifacts
+                command: |
+                  $Env:githash = git rev-parse --short HEAD 
+                  dotnet pack ./src/Okta.Idx.Sdk/Okta.Idx.Sdk.csproj --version-suffix $Env:githash --output ./artifacts
             - general-platform-helpers/step-artifacts-prepare-and-upload-windows:
                 files-to-upload: "nupkg"
                 location: "com/okta/devex/okta-idx-dotnet"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
                   $Env:githash = git rev-parse --short HEAD 
                   dotnet pack ./src/Okta.Idx.Sdk/Okta.Idx.Sdk.csproj --version-suffix $Env:githash --output ./artifacts
             - general-platform-helpers/step-artifacts-prepare-and-upload-windows:
-                files-to-upload: "nupkg"
+                files-to-upload: "artifacts"
                 location: "com/okta/devex/okta-idx-dotnet"
       - when:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:
-  "Circle CI Tests":
+  "Circle CI Build":
     jobs:
       - build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,17 @@ jobs:
                 location: "com/okta/devex/okta-idx-dotnet"
       - when:
           condition:
+            matches : { pattern: "^release-.+$", value: << pipeline.git.branch >> }
+          steps:
+            - run:
+                name: "Pack release package"
+                command: |
+                  dotnet pack ./src/Okta.Idx.Sdk/Okta.Idx.Sdk.csproj --configuration release --output ./artifacts
+            - general-platform-helpers/step-artifacts-prepare-and-upload-windows:
+                files-to-upload: "artifacts"
+                location: "com/okta/devex/okta-idx-dotnet"
+      - when:
+          condition:
             equal: [ "<<pipeline.git.branch>>", "master" ]
           steps:
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,18 @@ jobs:
               ./build.ps1;
       - when:
           condition:
+            matches : { pattern: "^test-.+$", value: << pipeline.git.branch >> }
+          steps:
+            - run:
+                name: "Pack test package"
+                  command: |
+                    $Env:githash = git rev-parse --short HEAD 
+                    dotnet pack ./src/Okta.Idx.Sdk/Okta.Idx.Sdk.csproj --version-suffix $Env:githash --output ./artifacts
+            - general-platform-helpers/step-artifacts-prepare-and-upload-windows:
+                files-to-upload: "nupkg"
+                location: "com/okta/devex/okta-idx-dotnet"
+      - when:
+          condition:
             equal: [ "<<pipeline.git.branch>>", "master" ]
           steps:
             - general-platform-helpers/step-artifacts-prepare-and-upload-windows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - run:
           name: "Install required components"
           command: |
-              choco install -y dotnetcore-sdk
+              choco install -y dotnet-6.0-sdk
       - run:
           name: "Test Runner"
           command: |

--- a/build.cake
+++ b/build.cake
@@ -189,8 +189,7 @@ Task("Default")
     .IsDependentOn("Clean")
     .IsDependentOn("Restore")
     .IsDependentOn("Build")
-    .IsDependentOn("Test")
-    .IsDependentOn("Pack");
+    .IsDependentOn("Test");
 
 Task("EmbeddedWidgetTest")
     .IsDependentOn("RestoreEmbeddedWidgetSampleApp")

--- a/build.cake
+++ b/build.cake
@@ -51,7 +51,7 @@ Task("Pack")
 .IsDependentOn("Build")
 .Does(() =>
 {
-    DotNetPack("./src/Okta.Idx.Sdk/Okta.Idx.Sdk.csproj", new DotNetCorePackSettings
+    DotNetCorePack("./src/Okta.Idx.Sdk/Okta.Idx.Sdk.csproj", new DotNetCorePackSettings
     {
         Configuration = configuration,
         OutputDirectory = "./artifacts/"

--- a/build.cake
+++ b/build.cake
@@ -51,7 +51,7 @@ Task("Pack")
 .IsDependentOn("Build")
 .Does(() =>
 {
-    DotNetCorePack("./src/Okta.Idx.Sdk/Okta.Idx.Sdk.csproj", new DotNetCorePackSettings
+    DotNetPack("./src/Okta.Idx.Sdk/Okta.Idx.Sdk.csproj", new DotNetCorePackSettings
     {
         Configuration = configuration,
         OutputDirectory = "./artifacts/"

--- a/src/Okta.Idx.Sdk/Okta.Idx.Sdk.csproj
+++ b/src/Okta.Idx.Sdk/Okta.Idx.Sdk.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
-    <Version>2.4.0</Version>
+    <VersionPrefix>2.4.0</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
The "Pack" command in the cake script builds packages that are rejected by the nuget.org server.  Updated the build config to use `dotnet pack` instead and was able to publish a resulting test package without issue.