### PR TITLE
fix System.Text.Json vuln

### DIFF
--- a/src/Okta.Idx.Sdk.UnitTests/Okta.Idx.Sdk.UnitTests.csproj
+++ b/src/Okta.Idx.Sdk.UnitTests/Okta.Idx.Sdk.UnitTests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="Okta.Sdk.Abstractions" Version="4.0.6" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.Json" Version="6.0.10" />
     <PackageReference Include="xunit" Version="2.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Okta.Idx.Sdk/Okta.Idx.Sdk.csproj
+++ b/src/Okta.Idx.Sdk/Okta.Idx.Sdk.csproj
@@ -24,6 +24,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <AdditionalFiles Include="..\stylecop.json" />
+    <PackageReference Include="System.Text.Json" Version="6.0.10" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Explicitly reference fixed version of System.Text.Json.

Fixes OKTA-818861, OKTA-818538