### PR TITLE
Adding the remediation step SelectAuthenticatorAuthenticate when RecoverPasswordAsync is performed with the recoverytoken

### DIFF
--- a/src/Okta.Idx.Sdk.UnitTests/IdxClientShould.cs
+++ b/src/Okta.Idx.Sdk.UnitTests/IdxClientShould.cs
@@ -4864,6 +4864,452 @@ namespace Okta.Idx.Sdk.UnitTests
         }
 
         [Fact]
+        public async Task ResetPasswordWithRecoveryToken()
+        {
+            #region mockResponses
+            string interactResponse = @"{ ""interaction_handle"":""AcSDZw_kwcQtFUwLAgyUyBzl_OifS5Nn6IZQ_X1WXWI""}";
+            string introspectResponse = @"{
+    ""version"": ""1.0.0"",
+    ""stateHandle"": ""02-kPJJDNxHMj4-nFhyzJZH_ZnSgEWX00X_jYUFP8G"",
+    ""expiresAt"": ""2021-06-01T16:18:16.000Z"",
+    ""intent"": ""LOGIN"",
+    ""remediation"": {
+        ""type"": ""array"",
+        ""value"": [
+            {
+                ""rel"": [
+                    ""create-form""
+                ],
+                ""name"": ""reset-authenticator"",
+                ""relatesTo"": [
+                    ""$.currentAuthenticator""
+                ],
+                ""href"": ""https://fake.example.com/idp/idx/challenge/answer"",
+                ""method"": ""POST"",
+                ""produces"": ""application/ion+json; okta-version=1.0.0"",
+                ""value"": [
+                    {
+                        ""name"": ""credentials"",
+                        ""type"": ""object"",
+                        ""form"": {
+                            ""value"": [
+                                {
+                                    ""name"": ""passcode"",
+                                    ""label"": ""New password"",
+                                    ""secret"": true
+                                }
+                            ]
+                        },
+                        ""required"": true
+                    },
+                    {
+                        ""name"": ""stateHandle"",
+                        ""required"": true,
+                        ""value"": ""02-kPJJDNxHMj4-nFhyzJZH_ZnSgEWX00X_jYUFP8G"",
+                        ""visible"": false,
+                        ""mutable"": false
+                    }
+                ],
+                ""accepts"": ""application/json; okta-version=1.0.0""
+            }
+        ]
+    },
+    ""currentAuthenticator"": {
+        ""type"": ""object"",
+        ""value"": {
+            ""type"": ""password"",
+            ""key"": ""okta_password"",
+            ""id"": ""autkuwj37bcjlumFq5d6"",
+            ""displayName"": ""Password"",
+            ""methods"": [
+                {
+                    ""type"": ""password""
+                }
+            ],
+            ""settings"": {
+                ""complexity"": {
+                    ""minLength"": 8,
+                    ""minLowerCase"": 1,
+                    ""minUpperCase"": 1,
+                    ""minNumber"": 1,
+                    ""minSymbol"": 0,
+                    ""excludeUsername"": true,
+                    ""excludeAttributes"": []
+                },
+                ""age"": {
+                    ""minAgeMinutes"": 0,
+                    ""historyCount"": 4
+                }
+            }
+        }
+    },
+    ""authenticators"": {
+        ""type"": ""array"",
+        ""value"": [
+            {
+                ""type"": ""password"",
+                ""key"": ""okta_password"",
+                ""id"": ""autkuwj37bcjlumFq5d6"",
+                ""displayName"": ""Password"",
+                ""methods"": [
+                    {
+                        ""type"": ""password""
+                    }
+                ]
+            }
+        ]
+    },
+    ""authenticatorEnrollments"": {
+        ""type"": ""array"",
+        ""value"": [
+            {
+                ""type"": ""email"",
+                ""key"": ""okta_email"",
+                ""id"": ""eaeuhtvnarGiKdWkr5d6"",
+                ""displayName"": ""Email"",
+                ""methods"": [
+                    {
+                        ""type"": ""email""
+                    }
+                ]
+            },
+            {
+                ""type"": ""password"",
+                ""key"": ""okta_password"",
+                ""id"": ""lae1xly261ebvEdcL5d6"",
+                ""displayName"": ""Password"",
+                ""methods"": [
+                    {
+                        ""type"": ""password""
+                    }
+                ]
+            },
+            {
+                ""type"": ""security_question"",
+                ""key"": ""security_question"",
+                ""id"": ""qaeuhtvngzUf3jXpz5d6"",
+                ""displayName"": ""Security Question"",
+                ""methods"": [
+                    {
+                        ""type"": ""security_question""
+                    }
+                ]
+            }
+        ]
+    },
+    ""recoveryAuthenticator"": {
+        ""type"": ""object"",
+        ""value"": {
+            ""type"": ""password"",
+            ""key"": ""okta_password"",
+            ""id"": ""autkuwj37bcjlumFq5d6"",
+            ""displayName"": ""Password"",
+            ""methods"": [
+                {
+                    ""type"": ""password""
+                }
+            ],
+            ""settings"": {
+                ""complexity"": {
+                    ""minLength"": 8,
+                    ""minLowerCase"": 1,
+                    ""minUpperCase"": 1,
+                    ""minNumber"": 1,
+                    ""minSymbol"": 0,
+                    ""excludeUsername"": true,
+                    ""excludeAttributes"": []
+                },
+                ""age"": {
+                    ""minAgeMinutes"": 0,
+                    ""historyCount"": 4
+                }
+            }
+        }
+    },
+    ""user"": {
+        ""type"": ""object"",
+        ""value"": {
+            ""id"": ""00uuhtvn9oIBAHaje5d6""
+        }
+    },
+    ""cancel"": {
+        ""rel"": [
+            ""create-form""
+        ],
+        ""name"": ""cancel"",
+        ""href"": ""fake.example.com/idp/idx/cancel"",
+        ""method"": ""POST"",
+        ""produces"": ""application/ion+json; okta-version=1.0.0"",
+        ""value"": [
+            {
+                ""name"": ""stateHandle"",
+                ""required"": true,
+                ""value"": ""02-kPJJDNxHMj4-nFhyzJZH_ZnSgEWX00X_jYUFP8G"",
+                ""visible"": false,
+                ""mutable"": false
+            }
+        ],
+        ""accepts"": ""application/json; okta-version=1.0.0""
+    },
+    ""app"": {
+        ""type"": ""object"",
+        ""value"": {
+            ""name"": ""oidc_client"",
+            ""label"": ""- Unit Test Web App"",
+            ""id"": ""0oatiq0j3Mw5an9Br5d6""
+        }
+    }
+}";
+            string challengeResponse = @"{
+                                           ""version"":""1.0.0"",
+                                           ""stateHandle"":""02Ne-0FN9pKGQELUTxhXSPXVmUtdDuZqO2381oihou"",
+                                           ""expiresAt"":""2021-05-28T20:48:44.000Z"",
+                                           ""intent"":""LOGIN"",
+                                           ""remediation"":{
+                                              ""type"":""array"",
+                                              ""value"":[
+                                                 {
+                                                    ""rel"":[
+                                                       ""create-form""
+                                                    ],
+                                                    ""name"":""authenticator-verification-data"",
+                                                    ""relatesTo"":[
+                                                       ""$.currentAuthenticatorEnrollment""
+                                                    ],
+                                                    ""href"":""https://foo/idp/idx/challenge"",
+                                                    ""method"":""POST"",
+                                                    ""produces"":""application/ion+json; okta-version=1.0.0"",
+                                                    ""value"":[
+                                                       {
+                                                          ""name"":""authenticator"",
+                                                          ""label"":""Phone"",
+                                                          ""form"":{
+                                                             ""value"":[
+                                                                {
+                                                                   ""name"":""id"",
+                                                                   ""required"":true,
+                                                                   ""value"":""auttzfsi4eiZIdLK85d6"",
+                                                                   ""mutable"":false
+                                                                },
+                                                                {
+                                                                   ""name"":""methodType"",
+                                                                   ""type"":""string"",
+                                                                   ""required"":true,
+                                                                   ""options"":[
+                                                                      {
+                                                                         ""label"":""SMS"",
+                                                                         ""value"":""sms""
+                                                                      }
+                                                                   ]
+                                                                },
+                                                                {
+                                                                   ""name"":""enrollmentId"",
+                                                                   ""required"":true,
+                                                                   ""value"":""smsu01v750pnUXuCH5d6"",
+                                                                   ""mutable"":false
+                                                                }
+                                                             ]
+                                                          }
+                                                       },
+                                                       {
+                                                          ""name"":""stateHandle"",
+                                                          ""required"":true,
+                                                          ""value"":""02Ne-0FN9pKGQELUTxhXSPXVmUtdDuZqO2381oihou"",
+                                                          ""visible"":false,
+                                                          ""mutable"":false
+                                                       }
+                                                    ],
+                                                    ""accepts"":""application/json; okta-version=1.0.0""
+                                                 },
+                                                 {
+                                                    ""rel"":[
+                                                       ""create-form""
+                                                    ],
+                                                    ""name"":""select-authenticator-authenticate"",
+                                                    ""href"":""https://foo/idp/idx/challenge"",
+                                                    ""method"":""POST"",
+                                                    ""produces"":""application/ion+json; okta-version=1.0.0"",
+                                                    ""value"":[
+                                                       {
+                                                          ""name"":""authenticator"",
+                                                          ""type"":""object"",
+                                                          ""options"":[
+                                                             {
+                                                                ""label"":""Phone"",
+                                                                ""value"":{
+                                                                   ""form"":{
+                                                                      ""value"":[
+                                                                         {
+                                                                            ""name"":""id"",
+                                                                            ""required"":true,
+                                                                            ""value"":""auttzfsi4eiZIdLK85d6"",
+                                                                            ""mutable"":false
+                                                                         },
+                                                                         {
+                                                                            ""name"":""methodType"",
+                                                                            ""type"":""string"",
+                                                                            ""required"":false,
+                                                                            ""options"":[
+                                                                               {
+                                                                                  ""label"":""SMS"",
+                                                                                  ""value"":""sms""
+                                                                               }
+                                                                            ]
+                                                                         },
+                                                                         {
+                                                                            ""name"":""enrollmentId"",
+                                                                            ""required"":true,
+                                                                            ""value"":""smsu01v750pnUXuCH5d6"",
+                                                                            ""mutable"":false
+                                                                         }
+                                                                      ]
+                                                                   }
+                                                                },
+                                                                ""relatesTo"":""$.authenticatorEnrollments.value[0]""
+                                                             }
+                                                          ]
+                                                       },
+                                                       {
+                                                          ""name"":""stateHandle"",
+                                                          ""required"":true,
+                                                          ""value"":""02Ne-0FN9pKGQELUTxhXSPXVmUtdDuZqO2381oihou"",
+                                                          ""visible"":false,
+                                                          ""mutable"":false
+                                                       }
+                                                    ],
+                                                    ""accepts"":""application/json; okta-version=1.0.0""
+                                                 }
+                                              ]
+                                           },
+                                           ""currentAuthenticatorEnrollment"":{
+                                              ""type"":""object"",
+                                              ""value"":{
+                                                 ""profile"":{
+                                                    ""phoneNumber"":""+1 XXX-XXX-4709""
+                                                 },
+                                                 ""resend"":{
+                                                    ""rel"":[
+                                                       ""create-form""
+                                                    ],
+                                                    ""name"":""resend"",
+                                                    ""href"":""https://foo/idp/idx/challenge/resend"",
+                                                    ""method"":""POST"",
+                                                    ""produces"":""application/ion+json; okta-version=1.0.0"",
+                                                    ""value"":[
+                                                       {
+                                                          ""name"":""stateHandle"",
+                                                          ""required"":true,
+                                                          ""value"":""02Ne-0FN9pKGQELUTxhXSPXVmUtdDuZqO2381oihou"",
+                                                          ""visible"":false,
+                                                          ""mutable"":false
+                                                       }
+                                                    ],
+                                                    ""accepts"":""application/json; okta-version=1.0.0""
+                                                 },
+                                                 ""type"":""phone"",
+                                                 ""key"":""phone_number"",
+                                                 ""id"":""smsu01v750pnUXuCH5d6"",
+                                                 ""displayName"":""Phone"",
+                                                 ""methods"":[
+                                                    {
+                                                       ""type"":""sms""
+                                                    }
+                                                 ]
+                                              }
+                                           },
+                                           ""authenticators"":{
+                                              ""type"":""array"",
+                                              ""value"":[
+                                                 {
+                                                    ""type"":""phone"",
+                                                    ""key"":""phone_number"",
+                                                    ""id"":""auttzfsi4eiZIdLK85d6"",
+                                                    ""displayName"":""Phone"",
+                                                    ""methods"":[
+                                                       {
+                                                          ""type"":""sms""
+                                                       }
+                                                    ]
+                                                 }
+                                              ]
+                                           },
+                                           ""authenticatorEnrollments"":{
+                                              ""type"":""array"",
+                                              ""value"":[
+                                                 {
+                                                    ""profile"":{
+                                                       ""phoneNumber"":""+1 XXX-XXX-4709""
+                                                    },
+                                                    ""type"":""phone"",
+                                                    ""key"":""phone_number"",
+                                                    ""id"":""smsu01v750pnUXuCH5d6"",
+                                                    ""displayName"":""Phone"",
+                                                    ""methods"":[
+                                                       {
+                                                          ""type"":""sms""
+                                                       }
+                                                    ]
+                                                 }
+                                              ]
+                                           },
+                                           ""user"":{
+                                              ""type"":""object"",
+                                              ""value"":{
+                                                 ""id"":""00utzmvli0oz5ReJB5d6""
+                                              }
+                                           },
+                                           ""cancel"":{
+                                              ""rel"":[
+                                                 ""create-form""
+                                              ],
+                                              ""name"":""cancel"",
+                                              ""href"":""https://foo/idp/idx/cancel"",
+                                              ""method"":""POST"",
+                                              ""produces"":""application/ion+json; okta-version=1.0.0"",
+                                              ""value"":[
+                                                 {
+                                                    ""name"":""stateHandle"",
+                                                    ""required"":true,
+                                                    ""value"":""02Ne-0FN9pKGQELUTxhXSPXVmUtdDuZqO2381oihou"",
+                                                    ""visible"":false,
+                                                    ""mutable"":false
+                                                 }
+                                              ],
+                                              ""accepts"":""application/json; okta-version=1.0.0""
+                                           },
+                                           ""app"":{
+                                              ""type"":""object"",
+                                              ""value"":{
+                                                 ""name"":""oidc_client"",
+                                                 ""label"":""Dotnet IDX Web App"",
+                                                 ""id"":""foo""
+                                              }
+                                           }
+                                        }";
+
+            #endregion
+
+            MockHttpMessageHandler mockHttpMessageHandler = new MockHttpMessageHandler();
+            mockHttpMessageHandler.AddTestResponse("/oauth2/v1/interact", interactResponse);
+            mockHttpMessageHandler.AddTestResponse("/idp/idx/introspect", introspectResponse);
+            mockHttpMessageHandler.AddTestResponse("/idp/idx/challenge/answer", challengeResponse);
+
+            HttpClient httpClient = new HttpClient(mockHttpMessageHandler);
+
+            IdxClient idxClient = new IdxClient(TesteableIdxClient.DefaultFakeConfiguration, httpClient, NullLogger.Instance);
+
+            RecoverPasswordOptions recoverPasswordOptions = new RecoverPasswordOptions
+            {
+                Username = "testuser@fake.com",
+                Passcode = "fake1",
+                RecoveryToken = "fake-recovery-token"
+            };
+            AuthenticationResponse authnResponse = await idxClient.RecoverPasswordAsync(recoverPasswordOptions);
+
+            Assert.Equal(AuthenticationStatus.AwaitingChallengeAuthenticatorSelection, authnResponse.AuthenticationStatus);
+        }
+
+        [Fact]
         public async Task ThrowWhenRecoverPasswordWithBadEmail()
         {
             string interactResponse = @"{

--- a/src/Okta.Idx.Sdk/IdxClient.cs
+++ b/src/Okta.Idx.Sdk/IdxClient.cs
@@ -1150,6 +1150,16 @@ namespace Okta.Idx.Sdk
                     var resetResponse = await resetAuthenticatorOption
                         .ProceedAsync(resetAuthenticatorRequest, cancellationToken);
 
+                    if (resetResponse.ContainsRemediationOption(RemediationType.SelectAuthenticatorAuthenticate))
+                    {
+                        return new AuthenticationResponse
+                        {
+                            IdxContext = idxContext,
+                            AuthenticationStatus = AuthenticationStatus.AwaitingChallengeAuthenticatorSelection,
+                            Authenticators = IdxResponseHelper.ConvertEnrollmentsToAuthenticators(resetResponse.Authenticators.Value, resetResponse.AuthenticatorEnrollments.Value),
+                        };
+                    }
+
                     if (resetResponse.IsLoginSuccess)
                     {
                         var tokenResponse = await resetResponse.SuccessWithInteractionCode.ExchangeCodeAsync(idxContext, cancellationToken);


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! A few things to know first:

- Before creating an issue or submitting a PR, please check that your issue is not already fixed in the latest stable version and that a similar issue or PR is not reported already (also check closed issues).
- For us to be able to merge your PR, you must first fill out a CLA. Information on our CLA process can be found at https://developer.okta.com/cla
- For faster reviews and merging, please fill out all sections of this template completely
- Your title should be concise and explain what the PR does
- Follow the single responsibility principal with your PR. This PR should adjust a single set of changes. If it is larger than that, please submit multiple PR's
- Please use this template for your PR, so we can understand the purpose. PR's that do not use this template will be closed
-->

## Summary
<!-- Be concise with your summary, but explain what changed -->
RecoverPasswordAsync function lags handling of the remediation steps after the password is changed when used with the recoverytoken 

<!-- Include the below line. If there is no issue associated with this PR, please use N/A -->
Fixes #231 

## Type of PR
<!-- Multiple selections are ok -->
- [x] Bug Fix (non-breaking fixes to existing functionality)

## Test Information
<!-- Please fill out all information -->
- [x] My PR required test updates <!-- If you can honestly answer no to this, you may skip this section -->

.NET Version: .NET Framework 4.7.2
Os Version: Microsoft Windows 11 Enterprise 64-bit

## Signoff
- [x] I have submitted a CLA for this PR
- [x] Each commit message explains what the commit does
- [x] I have updated documentation to explain what my PR does
- [x] My code is covered by tests if required
- [ ] I checked StyleCop warnings on my code

